### PR TITLE
Autonomous bootloader integration [1/2]

### DIFF
--- a/src/arch/cores/armv7-m/m4-core.h
+++ b/src/arch/cores/armv7-m/m4-core.h
@@ -1,24 +1,35 @@
-/* \file m4-core.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef M4_CORE_
 #define M4_CORE_

--- a/src/arch/cores/armv7-m/m4-core.h
+++ b/src/arch/cores/armv7-m/m4-core.h
@@ -1,0 +1,48 @@
+/* \file m4-core.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef M4_CORE_
+#define M4_CORE_
+
+#define MAIN_CLOCK_FREQUENCY 168000000
+#define MAIN_CLOCK_FREQUENCY_MS 168000
+#define MAIN_CLOCK_FREQUENCY_US 168
+
+#define INITIAL_STACK 0x1000b000
+
+#define INT_STACK_BASE KERN_STACK_BASE - 8192   /* same for FIQ & IRQ by now */
+#define ABT_STACK_BASE INT_STACK_BASE - 4096
+#define SYS_STACK_BASE ABT_STACK_BASE - 4096
+#define UDF_STACK_BASE SYS_STACK_BASE - 4096
+
+#define MODE_CLEAR 0xffffffe0
+
+static inline void core_processor_init_modes(void)
+{
+    /*
+     * init msp for kernel, this is needed in order to make IT return to SVC mode
+     * in thread mode (LR=0xFFFFFFF9) working (loading the good msp value from the SPSR)
+     */
+    asm volatile ("msr msp, %0\n\t"::"r" (INITIAL_STACK):);
+}
+
+#endif                          /*!M4_CORE_ */

--- a/src/arch/cores/armv7-m/m4-cpu.h
+++ b/src/arch/cores/armv7-m/m4-cpu.h
@@ -1,0 +1,203 @@
+/* \file m4-cpu.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef M4_CPU
+#define M4_CPU
+
+#include "types.h"
+
+__INLINE __attribute__ ((always_inline))
+void core_write_psp(void *ptr)
+{
+    asm volatile ("MSR psp, %0\n\t"::"r" (ptr));
+}
+
+__INLINE __attribute__ ((always_inline))
+void core_write_msp(void *ptr)
+{
+    asm volatile ("MSR msp, %0\n\t"::"r" (ptr));
+}
+
+__INLINE __attribute__ ((always_inline))
+void *core_read_psp(void)
+{
+    void *result = NULL;
+    asm volatile ("MRS %0, psp\n\t":"=r" (result));
+    return (result);
+}
+
+__INLINE __attribute__ ((always_inline))
+void *core_read_msp(void)
+{
+    void *result = NULL;
+    asm volatile ("MRS %0, msp\n\t":"=r" (result));
+    return (result);
+}
+
+__INLINE __attribute__ ((always_inline))
+void enable_irq(void)
+{
+    __ASM volatile ("cpsie i; isb":::"memory");
+}
+
+__INLINE __attribute__ ((always_inline))
+void disable_irq(void)
+{
+    __ASM volatile ("cpsid i":::"memory");
+
+}
+
+__INLINE __attribute__ ((always_inline))
+void full_memory_barrier(void)
+{
+    __ASM volatile ("dsb; isb":::);
+}
+
+__INLINE __attribute__ ((always_inline))
+uint32_t __get_CONTROL(void)
+{
+    uint32_t result;
+
+    __ASM volatile ("MRS %0, control":"=r" (result));
+    return (result);
+}
+
+__INLINE __attribute__ ((always_inline))
+void __set_CONTROL(uint32_t control)
+{
+    __ASM volatile ("MSR control, %0"::"r" (control));
+}
+
+__INLINE __attribute__ ((always_inline))
+uint32_t __get_IPSR(void)
+{
+    uint32_t result;
+
+    __ASM volatile ("MRS %0, ipsr":"=r" (result));
+    return (result);
+}
+
+__INLINE __attribute__ ((always_inline))
+uint32_t __get_APSR(void)
+{
+    uint32_t result;
+
+    __ASM volatile ("MRS %0, apsr":"=r" (result));
+    return (result);
+}
+
+__INLINE __attribute__ ((always_inline))
+uint32_t __get_xPSR(void)
+{
+    uint32_t result;
+
+    __ASM volatile ("MRS %0, xpsr":"=r" (result));
+    return (result);
+}
+
+__INLINE __attribute__ ((always_inline))
+uint32_t __get_PRIMASK(void)
+{
+    uint32_t result;
+
+    __ASM volatile ("MRS %0, primask":"=r" (result));
+    return (result);
+}
+
+__INLINE __attribute__ ((always_inline))
+void __set_PRIMASK(uint32_t priMask)
+{
+    __ASM volatile ("MSR primask, %0"::"r" (priMask));
+}
+
+__INLINE void wait_for_interrupt(void)
+{
+    asm volatile ("wfi");
+}
+
+#if defined(__CC_ARM)
+/* No Operation */
+#define __NOP		__nop
+/* Instruction Synchronization Barrier */
+#define __ISB()	__isb(0xF)
+/* Data Synchronization Barrier */
+#define __DSB()	__dsb(0xF)
+/* Data Memory Barrier */
+#define __DMB()	__dmb(0xF)
+/* Reverse byte order (32 bit) */
+#define __REV		__rev
+/* Reverse byte order (16 bit) */
+static __INLINE __ASM uint32_t __REV16(uint32_t value)
+{
+rev16 r0, r0 bx lr}
+/* Breakpoint */
+#define __BKPT	__bkpt
+#elif defined(__GNUC__)
+
+static inline __attribute__ ((always_inline))
+void __NOP(void)
+{
+    __asm__ volatile ("nop");
+}
+
+static inline __attribute__ ((always_inline))
+void __ISB(void)
+{
+    __asm__ volatile ("isb");
+}
+
+static inline __attribute__ ((always_inline))
+void __DSB(void)
+{
+    __asm__ volatile ("dsb");
+}
+
+static inline __attribute__ ((always_inline))
+void __DMB(void)
+{
+    __asm__ volatile ("dmb");
+}
+
+static inline __attribute__ ((always_inline))
+uint32_t __REV(uint32_t value)
+{
+    uint32_t result;
+    __asm__ volatile ("rev %0, %1":"=r" (result):"r"(value));
+    return result;
+}
+
+static inline __attribute__ ((always_inline))
+uint32_t __REV16(uint32_t value)
+{
+    uint32_t result;
+    __asm__ volatile ("rev16 %0, %1":"=r" (result):"r"(value));
+    return result;
+}
+
+static inline __attribute__ ((always_inline))
+void __BKPT(void)
+{
+    __asm__ volatile ("bkpt");
+}
+#endif
+
+#endif                          /*!M4_CPU */

--- a/src/arch/cores/armv7-m/m4-cpu.h
+++ b/src/arch/cores/armv7-m/m4-cpu.h
@@ -1,24 +1,35 @@
-/* \file m4-cpu.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef M4_CPU
 #define M4_CPU

--- a/src/arch/cores/armv7-m/m4-systick-regs.h
+++ b/src/arch/cores/armv7-m/m4-systick-regs.h
@@ -1,24 +1,35 @@
-/* \file m4-systick-regs.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef CORTEX_M4_SYSTICK_REGS_H
 #define CORTEX_M4_SYSTICK_REGS_H

--- a/src/arch/cores/armv7-m/m4-systick-regs.h
+++ b/src/arch/cores/armv7-m/m4-systick-regs.h
@@ -1,0 +1,111 @@
+/* \file m4-systick-regs.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef CORTEX_M4_SYSTICK_REGS_H
+#define CORTEX_M4_SYSTICK_REGS_H
+
+#include "soc-core.h"
+
+/* The processor has a 24-bit system timer, SysTick, that counts down from the reload value to
+ * zero, reloads (wraps to) the value in the STK_LOAD register on the next clock edge, then
+ * counts down on subsequent clocks.
+ * When the processor is halted for debugging the counter does not decrement.
+ *
+ * The SysTick counter runs on the processor clock. If this clock signal is stopped for low
+ * power mode, the SysTick counter stops.
+ * Ensure software uses aligned word accesses to access the SysTick registers.
+ *
+ * The SysTick counter reload and current value are undefined at reset,
+ * the correct initialization sequence for the SysTick counter is:
+ *  1. Program reload value.
+ *  2. Clear current value.
+ *  3. Program Control and Status register.
+ */
+
+/*** System timer registers ***/
+/* (RW Privileged)  SysTick control and status register (STK_CTRL) */
+#define r_CORTEX_M_STK_CTRL	REG_ADDR(SysTick_BASE + (uint32_t)0x00)
+/* (RW Privileged)  SysTick reload value register (STK_LOAD) */
+#define r_CORTEX_M_STK_LOAD	REG_ADDR(SysTick_BASE + (uint32_t)0x04)
+/* (RW Privileged)  SysTick current value register (STK_VAL) */
+#define r_CORTEX_M_STK_VAL	REG_ADDR(SysTick_BASE + (uint32_t)0x08)
+/* (RO Privileged)  SysTick calibration value register (STK_CALIB) */
+#define r_CORTEX_M_STK_CALIB	REG_ADDR(SysTick_BASE + (uint32_t)0x0C)
+
+/*** SysTick control and status register (STK_CTRL) ***/
+/* Bit 16 COUNTFLAG: Returns 1 if timer counted to 0 since last time this was
+ * read.
+ */
+#define STK_COUNTFLAG_Pos	16
+#define STK_COUNTFLAG_Msk	((uint32_t)0x01 << STK_COUNTFLAG_Pos)
+/* Bit 2 CLKSOURCE: Clock source selection*/
+#define STK_CLKSOURCE_Pos	2
+#define STK_CLKSOURCE_Msk	((uint32_t)0x01 << STK_CLKSOURCE_Pos)
+/* Bit 1 TICKINT: SysTick exception request enable*/
+#define STK_TICKINT_Pos	1
+#define STK_TICKINT_Msk	((uint32_t)0x01 << STK_TICKINT_Pos)
+/* Bit 0 ENABLE: Counter enable*/
+#define STK_ENABLE_Pos		0
+#define STK_ENABLE_Msk		((uint32_t)0x01 << STK_ENABLE_Pos)
+
+/*** SysTick reload value register (STK_LOAD) ***/
+/* Bits 23:0 RELOAD: RELOAD value The LOAD register specifies the start value
+ * to load into the STK_VAL register when the counter is enabled and when it
+ * reaches 0.
+ */
+#define STK_RELOAD_Pos		0
+#define STK_RELOAD_Msk		((uint32_t)0xffffff << STK_RELOAD_Pos)
+
+/*** SysTick current value register (STK_VAL) ***/
+/*  Bits 23:0 CURRENT: Current counter value. The VAL register contains the
+ *  current value of the SysTick counter. Reads return the current value of the
+ *  SysTick counter. A write of any value clears the field to 0, and also
+ *  clears the COUNTFLAG bit in the STK_CTRL register to 0.
+ */
+#define STK_CURRENT_Pos	0
+#define STK_CURRENT_Msk	((uint32_t)0xffffff << STK_CURRENT_Pos)
+
+/*** SysTick calibration value register (STK_CALIB) ***/
+/* Bit 31 NOREF: NOREF flag. Reads as zero. Indicates that a separate reference
+ * clock is provided. The frequency of this clock is HCLK/8.
+ */
+#define STK_NOREF_Pos		31
+#define STK_NOREF_Msk		((uint32_t)0x01 << STK_NOREF_Pos)
+/* Bit 30 SKEW: SKEW flag: Indicates whether the TENMS value is exact. Reads as
+ * one. Calibration value for the 1 ms inexact timing is not known because
+ * TENMS is not known. This can affect the suitability of SysTick as a software
+ * real time clock.
+ */
+#define STK_SKEW_Pos		30
+#define STK_SKEW_Msk		((uint32_t)0x01 << STK_SKEW_Pos)
+/* Bits 23:0 TENMS[23:0]: Calibration value. Indicates the calibration value
+ * when the SysTick counter runs on HCLK max/8 as external clock. The value is
+ * product dependent, please refer to the Product Reference Manual, SysTick
+ * Calibration Value section. When HCLK is programmed at the maximum frequency,
+ * the SysTick period is 1ms. If calibration information is not known,
+ * calculate the calibration value required from the frequency of the processor
+ * clock or external clock.
+ */
+#define STK_TENMS_Pos		0
+#define STK_TENMS_Msk		((uint32_t)0xffffff << STK_TENMS_Pos)
+
+#endif                          /* CORTEX_M4_SYSTICK_REGS_H */

--- a/src/arch/cores/armv7-m/m4-systick.c
+++ b/src/arch/cores/armv7-m/m4-systick.c
@@ -1,0 +1,52 @@
+/* \file m4-systick.c
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#include "m4-systick.h"
+#include "m4-systick-regs.h"
+#include "regutils.h"
+#include "soc-init.h"
+
+volatile unsigned long long ticks;
+
+void core_systick_init(void)
+{
+    set_reg(r_CORTEX_M_STK_LOAD, PROD_CORE_FREQUENCY, STK_RELOAD);
+    set_reg(r_CORTEX_M_STK_VAL, 0, STK_CURRENT);
+    set_reg_bits(r_CORTEX_M_STK_CTRL,
+                 STK_CLKSOURCE_Msk | STK_TICKINT_Msk | STK_ENABLE_Msk);
+}
+
+unsigned long long core_systick_get_ticks(void)
+{
+    return ticks;
+}
+
+unsigned long long core_ms_to_ticks(unsigned long long ms)
+{
+    return ms * TICKS_PER_SECOND / 1000;
+}
+
+stack_frame_t *core_systick_handler(stack_frame_t * stack_frame)
+{
+    ticks++;
+    return stack_frame;
+}

--- a/src/arch/cores/armv7-m/m4-systick.c
+++ b/src/arch/cores/armv7-m/m4-systick.c
@@ -1,24 +1,35 @@
-/* \file m4-systick.c
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #include "m4-systick.h"
 #include "m4-systick-regs.h"

--- a/src/arch/cores/armv7-m/m4-systick.h
+++ b/src/arch/cores/armv7-m/m4-systick.h
@@ -1,24 +1,35 @@
-/* m4-systick.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef CORTEX_M4_SYSTICK_H
 #define CORTEX_M4_SYSTICK_H

--- a/src/arch/cores/armv7-m/m4-systick.h
+++ b/src/arch/cores/armv7-m/m4-systick.h
@@ -1,0 +1,48 @@
+/* m4-systick.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef CORTEX_M4_SYSTICK_H
+#define CORTEX_M4_SYSTICK_H
+
+#include "types.h"
+#include "soc-interrupts.h"
+
+/* FIXME */
+#define TICKS_PER_SECOND    1000
+
+/**
+ * systick_init - Initialize the systick module
+ */
+void core_systick_init(void);
+
+/**
+ * get_ticks - Get the number of ticks elapsed since the card boot
+ * Return: Number of ticks.
+ */
+unsigned long long core_systick_get_ticks(void);
+
+unsigned long long core_ms_to_ticks(unsigned long long ms);
+
+/* ticks counter function, to be called by systick IRQ handler */
+stack_frame_t *core_systick_handler(stack_frame_t * stack_frame);
+
+#endif /* CORTEX_M4_SYSTICK_H */

--- a/src/arch/cores/armv7-m/types.h
+++ b/src/arch/cores/armv7-m/types.h
@@ -1,24 +1,35 @@
-/* \file arch/types.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef SOC_TYPES_H
 #define SOC_TYPES_H

--- a/src/arch/cores/armv7-m/types.h
+++ b/src/arch/cores/armv7-m/types.h
@@ -1,0 +1,73 @@
+/* \file arch/types.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef SOC_TYPES_H
+#define SOC_TYPES_H
+
+typedef signed char int8_t;
+typedef signed short int16_t;
+typedef signed int int32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long int uint64_t;
+/* fully typed log buffer size */
+typedef uint8_t logsize_t;
+
+typedef enum {false = 0, true = 1} bool;
+typedef enum {SUCCESS, FAILURE} retval_t;
+
+/* Secure boolean against fault injections for critical tests */
+typedef enum {secfalse = 0x55aa55aa, sectrue = 0xaa55aa55} secbool;
+
+#define KBYTE 1024
+#define MBYTE 1048576
+#define GBYTE 1073741824
+
+#define NULL				((void *)0)
+
+/* 32bits targets specific */
+typedef uint32_t physaddr_t;
+typedef uint8_t svcnum_t;
+
+#if defined(__CC_ARM)
+# define __ASM            __asm  /* asm keyword for ARM Compiler    */
+# define __INLINE         static __inline    /* inline keyword for ARM Compiler */
+# define __ISR_HANDLER           /* [PTH] todo: find the way to deactivate localy frame pointer or use rx, x<4 for it */
+# define __NAKED                 /* [PTH] todo: find the way to set the function naked (without pre/postamble) */
+# define __UNUSED                /* [PTH] todo: find the way to set a function/var unused */
+# define __WEAK                  /* [PTH] todo: find the way to set a function/var weak */
+#elif defined(__GNUC__)
+# define __ASM            __asm  /* asm keyword for GNU Compiler    */
+# define __INLINE        static inline
+#ifdef __clang__
+  # define __ISR_HANDLER  __attribute__((interrupt("IRQ")))
+#else
+  # define __ISR_HANDLER   __attribute__((optimize("-fomit-frame-pointer")))
+#endif
+# define __NAKED         __attribute__((naked))
+# define __UNUSED        __attribute__((unused))
+# define __WEAK          __attribute__((weak))
+# define __packed		__attribute__((__packed__))
+#endif
+
+#endif

--- a/src/arch/socs/stm32f439/soc-core.h
+++ b/src/arch/socs/stm32f439/soc-core.h
@@ -1,0 +1,143 @@
+/* \file soc-core.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef SOC_CORE_H
+#define SOC_CORE_H
+
+#include "soc-dwt.h"
+
+#if !defined  (__FPU_PRESENT)
+#define __FPU_PRESENT             1 /*!< FPU present                                   */
+#endif                          /* __FPU_PRESENT */
+#define __CM4_REV                 0x0001    /*!< Core revision r0p1                            */
+#define __MPU_PRESENT             1 /*!< STM32F4XX provides an MPU                     */
+#define __NVIC_PRIO_BITS          4 /*!< STM32F4XX uses 4 Bits for the Priority Levels */
+
+/* Memory mapping of Cortex-M3/M4 Hardware */
+#define CODE_BASE                           ((uint32_t) 0x00000000) /* Internal Flash Base Address */
+#define FLASH_BASE                          ((uint32_t) 0x08000000)
+#define SRAM_BASE                           ((uint32_t) 0x20000000) /* Internal SRAM Base Address */
+#define SRAM_BASE_BITBANG_BASE              ((uint32_t) 0x22000000) /* From (uint32_t)0x22000000UL to (uint32_t)0x23FFFFFFUL */
+#define PERIPH_BASE                         ((uint32_t) 0x40000000) /* Peripheral Base Address  */
+#define PERIPH_BASE_BITBANG1_BASE           ((uint32_t) 0x40000000) /* From (uint32_t)0x40000000UL to (uint32_t)0x400FFFFFUL */
+#define PERIPH_BASE_BITBANG2_BASE           ((uint32_t) 0x42000000) /* From (uint32_t)0x42000000UL to (uint32_t)0x43FFFFFFUL */
+#define EXTERNAL_RAM                        ((uint32_t) 0x60000000) /* From (uint32_t)0x60000000UL to (uint32_t)0x9FFFFFFFUL */
+#define EXTERNAL_DEVICE                     ((uint32_t) 0xA0000000) /* From (uint32_t)0xA0000000UL to (uint32_t)0xDFFFFFFFUL */
+#define SCS_BASE                            ((uint32_t) 0xE000E000) /* System Control Space Base Address                 */
+#define ITM_BASE                            ((uint32_t) 0xE0000000) /* TODO ITM Base Address                             */
+
+#define CoreDebug_BASE                      ((uint32_t) 0xE000EDF0) /* Core Debug Base Address                           */
+
+#define SysTick_BASE                        (SCS_BASE + (uint32_t) 0x010)   /* SysTick Base Address                              */
+#define NVIC_BASE                           (SCS_BASE + (uint32_t) 0x100)   /* NVIC Base Address                                 */
+#define SCB_BASE                            (SCS_BASE + (uint32_t) 0xd00)   /* System Control Block Base Address                 */
+
+#if (__FPU_PRESENT == 1)
+#define CPACR_BASE                          (SCB_BASE + (uint32_t) 0xd88)   /* Floating point unit coprocessor access control
+                                                                               register Base Address  */
+#else
+#warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+#define __FPU_USED       0
+#endif
+
+#if (__MPU_PRESENT == 1)
+#define MPU_BASE          (SCS_BASE +  (uint32_t) 0x0D90)   /* Memory Protection Unit */
+#else
+#warning "Using an MPU on device with no MPU (check __MPU_PRESENT)"
+#define __MPU_USED       0
+#endif
+
+#define NVIC_STIR_BASE                      (SCS_BASE + (uint32_t) 0xf00)   /* NVIC_STIR Base Address                            */
+
+#if (__FPU_PRESENT == 1)
+#define FPU_BASE          (SCS_BASE +  (uint32_t) 0x0F30)
+#else
+#warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+#define __FPU_USED       0
+#endif
+
+/*Peripheral memory map */
+#define APB1PERIPH_BASE       PERIPH_BASE
+#define APB2PERIPH_BASE       (PERIPH_BASE + 0x00010000)
+#define AHB1PERIPH_BASE       (PERIPH_BASE + 0x00020000)
+#define AHB2PERIPH_BASE       (PERIPH_BASE + 0x10000000)
+
+#define RCC_BASE              (AHB1PERIPH_BASE + 0x3800)
+
+/*APB1 peripherals */
+#define TIM2_BASE             (APB1PERIPH_BASE + 0x0000)
+#define TIM3_BASE             (APB1PERIPH_BASE + 0x0400)
+#define TIM4_BASE             (APB1PERIPH_BASE + 0x0800)
+#define TIM5_BASE             (APB1PERIPH_BASE + 0x0C00)
+#define TIM6_BASE             (APB1PERIPH_BASE + 0x1000)
+#define TIM7_BASE             (APB1PERIPH_BASE + 0x1400)
+#define TIM12_BASE            (APB1PERIPH_BASE + 0x1800)
+#define TIM13_BASE            (APB1PERIPH_BASE + 0x1C00)
+#define TIM14_BASE            (APB1PERIPH_BASE + 0x2000)
+#define RTC_BASE              (APB1PERIPH_BASE + 0x2800)
+#define WWDG_BASE             (APB1PERIPH_BASE + 0x2C00)
+#define IWDG_BASE             (APB1PERIPH_BASE + 0x3000)
+#define I2S2ext_BASE          (APB1PERIPH_BASE + 0x3400)
+#define SPI2_BASE             (APB1PERIPH_BASE + 0x3800)
+#define SPI3_BASE             (APB1PERIPH_BASE + 0x3C00)
+#define I2S3ext_BASE          (APB1PERIPH_BASE + 0x4000)
+#define USART2_BASE           (APB1PERIPH_BASE + 0x4400)
+#define USART3_BASE           (APB1PERIPH_BASE + 0x4800)
+#define UART4_BASE            (APB1PERIPH_BASE + 0x4C00)
+#define UART5_BASE            (APB1PERIPH_BASE + 0x5000)
+#define I2C1_BASE             (APB1PERIPH_BASE + 0x5400)
+#define I2C2_BASE             (APB1PERIPH_BASE + 0x5800)
+#define I2C3_BASE             (APB1PERIPH_BASE + 0x5C00)
+#define CAN1_BASE             (APB1PERIPH_BASE + 0x6400)
+#define CAN2_BASE             (APB1PERIPH_BASE + 0x6800)
+#define PWR_BASE              (APB1PERIPH_BASE + 0x7000)
+#define DAC_BASE              (APB1PERIPH_BASE + 0x7400)
+
+/*APB2 peripherals */
+#define TIM1_BASE             (APB2PERIPH_BASE + 0x0000)
+#define TIM8_BASE             (APB2PERIPH_BASE + 0x0400)
+#define USART1_BASE           (APB2PERIPH_BASE + 0x1000)
+#define USART6_BASE           (APB2PERIPH_BASE + 0x1400)
+#define ADC1_BASE             (APB2PERIPH_BASE + 0x2000)
+#define ADC2_BASE             (APB2PERIPH_BASE + 0x2100)
+#define ADC3_BASE             (APB2PERIPH_BASE + 0x2200)
+#define ADC_BASE              (APB2PERIPH_BASE + 0x2300)
+//#define SDIO_BASE             (APB2PERIPH_BASE + 0x2C00)
+#define SPI1_BASE             (APB2PERIPH_BASE + 0x3000)
+#define SYSCFG_BASE           (APB2PERIPH_BASE + 0x3800)
+#define EXTI_BASE             (APB2PERIPH_BASE + 0x3C00)
+#define TIM9_BASE             (APB2PERIPH_BASE + 0x4000)
+#define TIM10_BASE            (APB2PERIPH_BASE + 0x4400)
+#define TIM11_BASE            (APB2PERIPH_BASE + 0x4800)
+
+/*AHB1 peripherals */
+#define GPIOA_BASE            (AHB1PERIPH_BASE + 0x0000)
+#define GPIOB_BASE            (AHB1PERIPH_BASE + 0x0400)
+#define GPIOC_BASE            (AHB1PERIPH_BASE + 0x0800)
+#define GPIOD_BASE            (AHB1PERIPH_BASE + 0x0C00)
+#define GPIOE_BASE            (AHB1PERIPH_BASE + 0x1000)
+#define GPIOF_BASE            (AHB1PERIPH_BASE + 0x1400)
+#define GPIOG_BASE            (AHB1PERIPH_BASE + 0x1800)
+#define GPIOH_BASE            (AHB1PERIPH_BASE + 0x1C00)
+#define GPIOI_BASE            (AHB1PERIPH_BASE + 0x2000)
+
+#endif                          /* SOC_CORE_H */

--- a/src/arch/socs/stm32f439/soc-core.h
+++ b/src/arch/socs/stm32f439/soc-core.h
@@ -1,25 +1,37 @@
-/* \file soc-core.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #ifndef SOC_CORE_H
 #define SOC_CORE_H
 

--- a/src/arch/socs/stm32f439/soc-dwt.c
+++ b/src/arch/socs/stm32f439/soc-dwt.c
@@ -1,0 +1,82 @@
+/* \file soc-dwt.c
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include "soc-dwt.h"
+#include "m4-cpu.h"
+
+static uint32_t last_dwt = 0;
+
+static volatile uint64_t cyccnt_loop = 0;
+
+static volatile uint32_t* DWT_CONTROL = (volatile uint32_t*) 0xE0001000;
+static volatile uint32_t* SCB_DEMCR = (volatile uint32_t*) 0xE000EDFC;
+static volatile uint32_t* LAR = (volatile uint32_t*) 0xE0001FB0;
+static volatile uint32_t *DWT_CYCCNT = (volatile uint32_t *) 0xE0001004;
+
+void soc_dwt_reset_timer(void)
+{
+    *SCB_DEMCR = *(uint32_t *) SCB_DEMCR | 0x01000000;
+    *LAR = 0xC5ACCE55;
+    *DWT_CYCCNT = 0;   // reset the counter
+    *DWT_CONTROL = 0;
+   full_memory_barrier();
+}
+
+void soc_dwt_start_timer(void)
+{
+    *DWT_CONTROL = *DWT_CONTROL | 1;  // enable the counter
+   full_memory_barrier();
+}
+
+uint32_t soc_dwt_getcycles(void)
+{
+    return *DWT_CYCCNT;
+}
+
+uint64_t soc_dwt_getcycles_64(void)
+{
+    uint64_t val = *DWT_CYCCNT;
+    val += cyccnt_loop << 32;
+    return val;
+}
+
+
+void soc_dwt_ovf_manage(void)
+{
+    uint32_t dwt = soc_dwt_getcycles();
+
+    /*
+     * DWT cycle count overflow: we increment cyccnt_loop counter.
+     */
+    if (dwt < last_dwt) {
+        cyccnt_loop++;
+    }
+
+    last_dwt = dwt;
+}
+
+void soc_dwt_init(void)
+{
+    soc_dwt_reset_timer();
+    soc_dwt_start_timer();
+}

--- a/src/arch/socs/stm32f439/soc-dwt.c
+++ b/src/arch/socs/stm32f439/soc-dwt.c
@@ -1,26 +1,36 @@
-/* \file soc-dwt.c
+/*
+ * copyright 2019 the wookey project team <wookey@ssi.gouv.fr>
+ *   - ryad     benadjila
+ *   - arnauld  michelizza
+ *   - mathieu  renard
+ *   - philippe thierry
+ *   - philippe trebuchet
+ * all rights reserved.
  *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
- *   - Ryad     Benadjila
- *   - Arnauld  Michelizza
- *   - Mathieu  Renard
- *   - Philippe Thierry
- *   - Philippe Trebuchet
+ * redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * 1. redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * this software is provided by the copyright holders and contributors "as is"
+ * and any express or implied warranties, including, but not limited to, the
+ * implied warranties of merchantability and fitness for a particular purpose
+ * are disclaimed. in no event shall the copyright owner or contributors be
+ * liable for any direct, indirect, incidental, special, exemplary, or
+ * consequential damages (including, but not limited to, procurement of
+ * substitute goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether in
+ * contract, strict liability, or tort (including negligence or otherwise)
+ * arising in any way out of the use of this software, even if advised of the
+ * possibility of such damage.
  */
-
 #include "soc-dwt.h"
 #include "m4-cpu.h"
 

--- a/src/arch/socs/stm32f439/soc-dwt.h
+++ b/src/arch/socs/stm32f439/soc-dwt.h
@@ -1,0 +1,42 @@
+/* \file soc-dwt.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef SOC_DWT_H
+#define SOC_DWT_H
+
+#include "types.h"
+
+void soc_dwt_init(void);
+
+void soc_dwt_reset_timer(void);
+
+void soc_dwt_start_timer(void);
+
+void soc_dwt_stop_timer(void);
+
+uint32_t soc_dwt_getcycles(void);
+
+uint64_t soc_dwt_getcycles_64(void);
+
+void soc_dwt_ovf_manage(void);
+
+#endif /*!SOC_DWT_H */

--- a/src/arch/socs/stm32f439/soc-dwt.h
+++ b/src/arch/socs/stm32f439/soc-dwt.h
@@ -1,24 +1,35 @@
-/* \file soc-dwt.h
+/*
+ * copyright 2019 the wookey project team <wookey@ssi.gouv.fr>
+ *   - ryad     benadjila
+ *   - arnauld  michelizza
+ *   - mathieu  renard
+ *   - philippe thierry
+ *   - philippe trebuchet
+ * all rights reserved.
  *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
- *   - Ryad     Benadjila
- *   - Arnauld  Michelizza
- *   - Mathieu  Renard
- *   - Philippe Thierry
- *   - Philippe Trebuchet
+ * redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * 1. redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * this software is provided by the copyright holders and contributors "as is"
+ * and any express or implied warranties, including, but not limited to, the
+ * implied warranties of merchantability and fitness for a particular purpose
+ * are disclaimed. in no event shall the copyright owner or contributors be
+ * liable for any direct, indirect, incidental, special, exemplary, or
+ * consequential damages (including, but not limited to, procurement of
+ * substitute goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether in
+ * contract, strict liability, or tort (including negligence or otherwise)
+ * arising in any way out of the use of this software, even if advised of the
+ * possibility of such damage.
  */
 #ifndef SOC_DWT_H
 #define SOC_DWT_H

--- a/src/arch/socs/stm32f439/soc-flash.h
+++ b/src/arch/socs/stm32f439/soc-flash.h
@@ -1,24 +1,35 @@
-/* \file soc-flash.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef SOC_FLASH_H
 #define SOC_FLASH_H

--- a/src/arch/socs/stm32f439/soc-flash.h
+++ b/src/arch/socs/stm32f439/soc-flash.h
@@ -1,0 +1,282 @@
+/* \file soc-flash.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef SOC_FLASH_H
+#define SOC_FLASH_H
+
+#include "soc-core.h"
+
+#define r_CORTEX_M_FLASH		REG_ADDR(AHB1PERIPH_BASE + (uint32_t)0x3C00)
+
+#define r_CORTEX_M_FLASH_ACR		(r_CORTEX_M_FLASH + (uint32_t)0x00) /* FLASH access control register */
+#define r_CORTEX_M_FLASH_KEYR		(r_CORTEX_M_FLASH + (uint32_t)0x01) /* FLASH key register 1 */
+#define r_CORTEX_M_FLASH_OPTKEYR	(r_CORTEX_M_FLASH + (uint32_t)0x02) /* FLASH option key register */
+#define r_CORTEX_M_FLASH_SR		(r_CORTEX_M_FLASH + (uint32_t)0x03) /* FLASH status register */
+#define r_CORTEX_M_FLASH_CR		(r_CORTEX_M_FLASH + (uint32_t)0x04) /* FLASH control register */
+#define r_CORTEX_M_FLASH_OPTCR		(r_CORTEX_M_FLASH + (uint32_t)0x05) /* FLASH option control register */
+#ifdef STM32F429                /* FLASH option control register 1 (only on f42xxx/43xxx) */
+#define r_CORTEX_M_FLASH_OPTCR1		(r_CORTEX_M_FLASH + (uint32_t)0x06)
+#endif
+
+/*******************  FLASH_ACR register  *****************/
+#define FLASH_ACR_LATENCY_Pos		0
+#define FLASH_ACR_LATENCY_Msk		((uint32_t)7 << FLASH_ACR_LATENCY_Pos)
+#define FLASH_ACR_PRFTEN_Pos		8
+#define FLASH_ACR_PRFTEN_Msk		((uint32_t)1 << FLASH_ACR_PRFTEN_Pos)
+#define FLASH_ACR_ICEN_Pos 		9
+#define FLASH_ACR_ICEN_Msk		((uint32_t)1 << FLASH_ACR_ICEN_Pos)
+#define FLASH_ACR_DCEN_Pos		10
+#define FLASH_ACR_DCEN_Msk		((uint32_t)1 << FLASH_ACR_DCEN_Pos)
+#define FLASH_ACR_ICRST_Pos		11
+#define FLASH_ACR_ICRST_Msk		((uint32_t)1 << FLASH_ACR_ICRST_Pos)
+#define FLASH_ACR_DCRST_Pos		12
+#define FLASH_ACR_DCRST_Msk		((uint32_t)1 << FLASH_ACR_DCRST_Pos)
+
+/*******************  Flash key register  ***************/
+#define KEY1				((uint32_t)0x45670123)
+#define KEY2				((uint32_t)0xCDEF89AB)
+
+/*******************  Flash option key register  ***************/
+#define OPTKEY1				((uint32_t)0x08192A3B)
+#define OPTKEY2				((uint32_t)0x4C5D6E7F)
+
+/*******************  FLASH_SR register  ******************/
+#define FLASH_SR_EOP_Pos		0
+#define FLASH_SR_EOP_Msk 		((uint32_t)1 << FLASH_SR_EOP_Pos)
+#define FLASH_SR_OPERR_Pos		1
+#define FLASH_SR_OPERR_Msk		((uint32_t)1 << FLASH_SR_OPERR_Pos)
+#define FLASH_SR_WRPERR_Pos		4
+#define FLASH_SR_WRPERR_Msk		((uint32_t)1 << FLASH_SR_WRPERR_Pos)
+#define FLASH_SR_PGAERR_Pos		5
+#define FLASH_SR_PGAERR_Msk		((uint32_t)1 << FLASH_SR_PGAERR_Pos)
+#define FLASH_SR_PGPERR_Pos		6
+#define FLASH_SR_PGPERR_Msk		((uint32_t)1 << FLASH_SR_PGPERR_Pos)
+#define FLASH_SR_PGSERR_Pos		7
+#define FLASH_SR_PGSERR_Msk		((uint32_t)1 << FLASH_SR_PGSERR_Pos)
+#ifdef STM32F429                /* RDERR only on f42xxx/43xxx */
+#define FLASH_SR_RDERR_Pos		8
+#define FLASH_SR_RDERR_Msk		((uint32_t)1 << FLASH_SR_RDERR_Pos)
+#endif
+#define FLASH_SR_BSY_Pos   		16
+#define FLASH_SR_BSY_Msk  		((uint32_t)1 << FLASH_SR_BSY_Pos)
+
+/*******************  FLASH_CR register  ******************/
+#define FLASH_CR_PG_Pos 		0
+#define FLASH_CR_PG_Msk  		((uint32_t)1 << FLASH_CR_PG_Pos)
+#define FLASH_CR_SER_Pos 		1
+#define FLASH_CR_SER_Msk		((uint32_t)1 << FLASH_CR_SER_Pos)
+#define FLASH_CR_MER_Pos		2
+#define FLASH_CR_MER_Msk		((uint32_t)1 << FLASH_CR_MER_Pos)
+#define FLASH_CR_SNB_Pos		3
+#define FLASH_CR_SNB_Msk		((uint32_t)0xF << FLASH_CR_SNB_Pos)
+#define FLASH_CR_PSIZE_Pos		8
+#define FLASH_CR_PSIZE_Msk		((uint32_t)3 << FLASH_CR_PSIZE_Pos)
+#ifdef STM32F429                /* MER1 only on f42xxx/43xxx */
+#define FLASH_CR_MER1_Pos		15
+#define FLASH_CR_MER1_Msk		((uint32_t)1 << FLASH_CR_MER1_Pos)
+#endif
+#define FLASH_CR_STRT_Pos		16
+#define FLASH_CR_STRT_Msk		((uint32_t)1 << FLASH_CR_STRT_Pos)
+#define FLASH_CR_EOPIE_Pos		24
+#define FLASH_CR_EOPIE_Msk		((uint32_t)1 << FLASH_CR_EOPIE_Pos)
+#define FLASH_CR_ERRIE_Pos		25
+#define FLASH_CR_ERRIE_Msk		((uint32_t)1 << FLASH_CR_ERRIE_Pos)
+#define FLASH_CR_LOCK_Pos 		31
+#define FLASH_CR_LOCK_Msk 		((uint32_t)1 << FLASH_CR_LOCK_Pos)
+
+/*******************  FLASH_OPTCR register  ***************/
+#define FLASH_OPTCR_OPTLOCK_Pos		0
+#define FLASH_OPTCR_OPTLOCK_Msk		((uint32_t)1 << FLASH_OPTCR_OPTLOCK_Pos)
+#define FLASH_OPTCR_OPTSTRT_Pos		1
+#define FLASH_OPTCR_OPTSTRT_Msk		((uint32_t)1 << FLASH_OPTCR_OPTSTRT_Pos)
+#define FLASH_OPTCR_BOR_LEV_Pos		2
+#define FLASH_OPTCR_BOR_LEV_Msk		((uint32_t)3 << FLASH_OPTCR_BOR_LEV_Pos)
+#ifdef STM32F429                /* BFB2 only on f42xxx/43xxx */
+#define FLASH_OPTCR_BFB2_Pos		4
+#define FLASH_OPTCR_BFB2_Msk		((uint32_t)1 << FLASH_OPTCR_BFB2_Pos)
+#endif
+#define FLASH_OPTCR_WDG_SW_Pos		5
+#define FLASH_OPTCR_WDG_SW_Msk		((uint32_t)1 << FLASH_OPTCR_WDG_SW_Pos)
+#define FLASH_OPTCR_nRST_STOP_Pos	6
+#define FLASH_OPTCR_nRST_STOP_Msk	((uint32_t)1 << FLASH_OPTCR_nRST_STOP_Pos)
+#define FLASH_OPTCR_nRST_STDBY_Pos	7
+#define FLASH_OPTCR_nRST_STDBY_Msk	((uint32_t)1 << FLASH_OPTCR_nRST_STDBY_Pos)
+#define FLASH_OPTCR_RDP_Pos		8
+#define FLASH_OPTCR_RDP_Msk		((uint32_t)0xFF << FLASH_OPTCR_RDP_Pos)
+#define FLASH_OPTCR_nWRP_Pos		16
+#define FLASH_OPTCR_nWRP_Msk		((uint32_t)0x0FFF << FLASH_OPTCR_nWRP_Pos)
+#ifdef STM32F429                /* STM32F42xxx/STM32F43xxx only */
+#define FLASH_OPTCR_DB1M_Pos		30
+#define FLASH_OPTCR_DB1M_Msk		((uint32_t)1 << FLASH_OPTCR_DB1M_Pos)
+#define FLASH_OPTCR_SPRMOD_Pos		31
+#define FLASH_OPTCR_SPRMOD_Msk		((uint32_t)1 << FLASH_OPTCR_SPRMOD_Pos)
+#endif
+
+/*******************  FLASH_OPTCR1 register  ***************/
+#ifdef STM32F429    /**** Only on f42xxx/43xxx ****/
+#define FLASH_OPTCR1_nWRP_Pos		16
+#define FLASH_OPTCR1_nWRP_Msk		((uint32_t)0x0FFF << FLASH_OPTCR1_nWRP_Pos)
+#endif
+
+/****** Adress definition for flash memory sectors ******/
+/*** Single bank configuration ***/
+#define FLASH_SECTOR_0			((uint32_t) 0x08000000) /* 16 kB */
+#define FLASH_SECTOR_0_END		((uint32_t) 0x08003FFF)
+#define FLASH_SECTOR_1			((uint32_t) 0x08004000) /* 16 kB */
+#define FLASH_SECTOR_1_END		((uint32_t) 0x08007FFF)
+#define FLASH_SECTOR_2			((uint32_t) 0x08008000) /* 16 kB */
+#define FLASH_SECTOR_2_END		((uint32_t) 0x0800BFFF)
+#define FLASH_SECTOR_3			((uint32_t) 0x0800C000) /* 16 kB */
+#define FLASH_SECTOR_3_END		((uint32_t) 0x0800FFFF)
+#define FLASH_SECTOR_4			((uint32_t) 0x08010000) /* 64 kB */
+#define FLASH_SECTOR_4_END		((uint32_t) 0x0801FFFF)
+#define FLASH_SECTOR_5			((uint32_t) 0x08020000) /* 128 kB */
+#define FLASH_SECTOR_5_END		((uint32_t) 0x0803FFFF)
+#define FLASH_SECTOR_6			((uint32_t) 0x08040000) /* 128 kB */
+#define FLASH_SECTOR_6_END		((uint32_t) 0x0805FFFF)
+#define FLASH_SECTOR_7			((uint32_t) 0x08060000) /* 128 kB */
+#define FLASH_SECTOR_7_END		((uint32_t) 0x0807FFFF)
+#define FLASH_SECTOR_8			((uint32_t) 0x08080000) /* 128 kB */
+#define FLASH_SECTOR_8_END		((uint32_t) 0x0809FFFF)
+#define FLASH_SECTOR_9			((uint32_t) 0x080A0000) /* 128 kB */
+#define FLASH_SECTOR_9_END		((uint32_t) 0x080BFFFF)
+#define FLASH_SECTOR_10			((uint32_t) 0x080C0000) /* 128 kB */
+#define FLASH_SECTOR_10_END		((uint32_t) 0x080DFFFF)
+#define FLASH_SECTOR_11			((uint32_t) 0x080E0000) /* 128 kB */
+#define FLASH_SECTOR_11_END		((uint32_t) 0x080FFFFF)
+#define FLASH_SECTOR_SYSTEM_MEM		((uint32_t) 0x1FFF0000) /* 30 kB */
+#define FLASH_SECTOR_SYSTEM_MEM_END	((uint32_t) 0x1FFF77FF)
+#define FLASH_SECTOR_OPT_AREA		((uint32_t) 0x1FFF7800) /* 528 B */
+#define FLASH_SECTOR_OPT_AREA_END	((uint32_t) 0x1FFF7A0F)
+#define FLASH_OPTION_BYTES		((uint32_t) 0x1FFFC000) /* 16 B */
+#define FLASH_OPTION_BYTES_END		((uint32_t) 0x1FFFC00F)
+#ifdef STM32F429                /* ! Only in f42xxx/43xxx ! */
+#define FLASH_OPTION_BYTES_SGL		((uint32_t) 0x1FFEC000) /* 16 B */
+#define FLASH_OPTION_BYTES_SGL_END	((uint32_t) 0x1FFEC00F)
+#endif
+
+/*** 1MB Dual bank memory configuration (8 first sector & opt bytes unchanged) ***/
+#define FLASH_SECTOR_12			((uint32_t) 0x08080000) /* 16 kB */
+#define FLASH_SECTOR_12_END		((uint32_t) 0x08083FFF)
+#define FLASH_SECTOR_13			((uint32_t) 0x08084000) /* 16 kB */
+#define FLASH_SECTOR_13_END		((uint32_t) 0x08087FFF)
+#define FLASH_SECTOR_14			((uint32_t) 0x08088000) /* 16 kB */
+#define FLASH_SECTOR_14_END		((uint32_t) 0x0808BFFF)
+#define FLASH_SECTOR_15			((uint32_t) 0x0808C000) /* 16 kB */
+#define FLASH_SECTOR_15_END		((uint32_t) 0x0808FFFF)
+#define FLASH_SECTOR_16			((uint32_t) 0x08090000) /* 64 kB */
+#define FLASH_SECTOR_16_END		((uint32_t) 0x0809FFFF)
+#define FLASH_SECTOR_17			((uint32_t) 0x080A0000) /* 128 kB */
+#define FLASH_SECTOR_17_END		((uint32_t) 0x080BFFFF)
+#define FLASH_SECTOR_18			((uint32_t) 0x080A0000) /* 128 kB */
+#define FLASH_SECTOR_18_END		((uint32_t) 0x080BFFFF)
+#define FLASH_SECTOR_19			((uint32_t) 0x080C0000) /* 128 kB */
+#define FLASH_SECTOR_19_END		((uint32_t) 0x080DFFFF)
+#define FLASH_OPTION_BYTES_BK1		((uint32_t) 0x1FFFC000) /* 16 B */
+#define FLASH_OPTION_BYTES_BK1_END	((uint32_t) 0x1FFFC00F)
+#define FLASH_OPTION_BYTES_BK2		((uint32_t) 0x1FFEC000) /* 16 B */
+#define FLASH_OPTION_BYTES_BK2_END	((uint32_t) 0x1FFEC00F)
+
+#define IS_IN_FLASH(addr)		((addr) >= FLASH_SECTOR_0) && \
+					((addr) <= FLASH_SECTOR_11_END)
+
+#define IS_IN_FLASH_DUAL(addr)		((addr) >= FLASH_SECTOR_0) && \
+					((addr) <= FLASH_SECTOR_11_END) || \
+					((addr) >= FLASH_SECTOR_12) && \
+					((addr) <= FLASH_SECTOR_19_END)
+
+//#define START_SECTOR(SECTOR)          (uint32_t)FLASH_SECTOR_##SECTOR
+//#define END_SECTOR(SECTOR)            (uint32_t)FLASH_SECTOR_##SECTOR##_END
+
+/*******************  Bits definition for FLASH_ACR register  *****************/
+#define FLASH_ACR_LATENCY                    ((uint32_t)0x00000007)
+#define FLASH_ACR_LATENCY_0WS                ((uint32_t)0x00000000)
+#define FLASH_ACR_LATENCY_1WS                ((uint32_t)0x00000001)
+#define FLASH_ACR_LATENCY_2WS                ((uint32_t)0x00000002)
+#define FLASH_ACR_LATENCY_3WS                ((uint32_t)0x00000003)
+#define FLASH_ACR_LATENCY_4WS                ((uint32_t)0x00000004)
+#define FLASH_ACR_LATENCY_5WS                ((uint32_t)0x00000005)
+#define FLASH_ACR_LATENCY_6WS                ((uint32_t)0x00000006)
+#define FLASH_ACR_LATENCY_7WS                ((uint32_t)0x00000007)
+
+#define FLASH_ACR_PRFTEN                     ((uint32_t)0x00000100)
+#define FLASH_ACR_ICEN                       ((uint32_t)0x00000200)
+#define FLASH_ACR_DCEN                       ((uint32_t)0x00000400)
+#define FLASH_ACR_ICRST                      ((uint32_t)0x00000800)
+#define FLASH_ACR_DCRST                      ((uint32_t)0x00001000)
+#define FLASH_ACR_BYTE0_ADDRESS              ((uint32_t)0x40023C00)
+#define FLASH_ACR_BYTE2_ADDRESS              ((uint32_t)0x40023C03)
+
+/*******************  Bits definition for FLASH_SR register  ******************/
+#define FLASH_SR_EOP                         ((uint32_t)0x00000001)
+#define FLASH_SR_SOP                         ((uint32_t)0x00000002)
+#define FLASH_SR_WRPERR                      ((uint32_t)0x00000010)
+#define FLASH_SR_PGAERR                      ((uint32_t)0x00000020)
+#define FLASH_SR_PGPERR                      ((uint32_t)0x00000040)
+#define FLASH_SR_PGSERR                      ((uint32_t)0x00000080)
+#define FLASH_SR_BSY                         ((uint32_t)0x00010000)
+
+/*******************  Bits definition for FLASH_CR register  ******************/
+#define FLASH_CR_PG                          ((uint32_t)0x00000001)
+#define FLASH_CR_SER                         ((uint32_t)0x00000002)
+#define FLASH_CR_MER                         ((uint32_t)0x00000004)
+#define FLASH_CR_SNB_0                       ((uint32_t)0x00000008)
+#define FLASH_CR_SNB_1                       ((uint32_t)0x00000010)
+#define FLASH_CR_SNB_2                       ((uint32_t)0x00000020)
+#define FLASH_CR_SNB_3                       ((uint32_t)0x00000040)
+#define FLASH_CR_PSIZE_0                     ((uint32_t)0x00000100)
+#define FLASH_CR_PSIZE_1                     ((uint32_t)0x00000200)
+#define FLASH_CR_STRT                        ((uint32_t)0x00010000)
+#define FLASH_CR_EOPIE                       ((uint32_t)0x01000000)
+#define FLASH_CR_LOCK                        ((uint32_t)0x80000000)
+
+/*******************  Bits definition for FLASH_OPTCR register  ***************/
+#define FLASH_OPTCR_OPTLOCK                  ((uint32_t)0x00000001)
+#define FLASH_OPTCR_OPTSTRT                  ((uint32_t)0x00000002)
+#define FLASH_OPTCR_BOR_LEV_0                ((uint32_t)0x00000004)
+#define FLASH_OPTCR_BOR_LEV_1                ((uint32_t)0x00000008)
+#define FLASH_OPTCR_BOR_LEV                  ((uint32_t)0x0000000C)
+#define FLASH_OPTCR_WDG_SW                   ((uint32_t)0x00000020)
+#define FLASH_OPTCR_nRST_STOP                ((uint32_t)0x00000040)
+#define FLASH_OPTCR_nRST_STDBY               ((uint32_t)0x00000080)
+#define FLASH_OPTCR_RDP_0                    ((uint32_t)0x00000100)
+#define FLASH_OPTCR_RDP_1                    ((uint32_t)0x00000200)
+#define FLASH_OPTCR_RDP_2                    ((uint32_t)0x00000400)
+#define FLASH_OPTCR_RDP_3                    ((uint32_t)0x00000800)
+#define FLASH_OPTCR_RDP_4                    ((uint32_t)0x00001000)
+#define FLASH_OPTCR_RDP_5                    ((uint32_t)0x00002000)
+#define FLASH_OPTCR_RDP_6                    ((uint32_t)0x00004000)
+#define FLASH_OPTCR_RDP_7                    ((uint32_t)0x00008000)
+#define FLASH_OPTCR_nWRP_0                   ((uint32_t)0x00010000)
+#define FLASH_OPTCR_nWRP_1                   ((uint32_t)0x00020000)
+#define FLASH_OPTCR_nWRP_2                   ((uint32_t)0x00040000)
+#define FLASH_OPTCR_nWRP_3                   ((uint32_t)0x00080000)
+#define FLASH_OPTCR_nWRP_4                   ((uint32_t)0x00100000)
+#define FLASH_OPTCR_nWRP_5                   ((uint32_t)0x00200000)
+#define FLASH_OPTCR_nWRP_6                   ((uint32_t)0x00400000)
+#define FLASH_OPTCR_nWRP_7                   ((uint32_t)0x00800000)
+#define FLASH_OPTCR_nWRP_8                   ((uint32_t)0x01000000)
+#define FLASH_OPTCR_nWRP_9                   ((uint32_t)0x02000000)
+#define FLASH_OPTCR_nWRP_10                  ((uint32_t)0x04000000)
+#define FLASH_OPTCR_nWRP_11		     ((uint32_t)0x08000000)
+
+#endif /* !SOC_FLASH_H */

--- a/src/arch/socs/stm32f439/soc-gpio.c
+++ b/src/arch/socs/stm32f439/soc-gpio.c
@@ -1,0 +1,257 @@
+/* \file soc-gpio.c
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#include "types.h"
+#include "gpio.h"
+#include "soc-gpio.h"
+
+/*
+** Convert a port num (0x0 = GPIOA, 0x1 = GPIOB...) into port base address
+*/
+static uint32_t soc_gpio_get_port_base (gpioref_t kref)
+{
+    uint32_t port_base;
+    switch (kref.port) {
+	    case GPIO_PA: port_base = GPIOA_BASE; break;
+	    case GPIO_PB: port_base = GPIOB_BASE; break;
+	    case GPIO_PC: port_base = GPIOC_BASE; break;
+	    case GPIO_PD: port_base = GPIOD_BASE; break;
+	    case GPIO_PE: port_base = GPIOE_BASE; break;
+	    case GPIO_PF: port_base = GPIOF_BASE; break;
+	    case GPIO_PG: port_base = GPIOG_BASE; break;
+	    case GPIO_PH: port_base = GPIOH_BASE; break;
+	    case GPIO_PI: port_base = GPIOI_BASE; break;
+	    default:
+	        port_base = 0;
+	        break;
+    }
+    return port_base;
+}
+
+bool soc_gpio_exists(gpioref_t kref)
+{
+    if (soc_gpio_get_port_base(kref) == 0) {
+        return false;
+    }
+    return true;
+}
+
+void soc_gpio_set_mode(volatile uint32_t * gpioX_moder, uint8_t pin,
+                       uint8_t mode)
+{
+    set_reg_value(gpioX_moder, mode, 0x3 << (2 * pin), 2 * pin);
+}
+
+void soc_gpio_set_type(volatile uint32_t * gpioX_otyper, uint8_t pin,
+                       uint8_t type)
+{
+    set_reg_value(gpioX_otyper, type, 1 << pin, pin);
+}
+
+void soc_gpio_set_speed(volatile uint32_t * gpioX_ospeedr, uint8_t pin,
+                        uint8_t speed)
+{
+    set_reg_value(gpioX_ospeedr, speed, 0x3 << (2 * pin), 2 * pin);
+}
+
+void soc_gpio_set_pupd(volatile uint32_t * gpioX_pupdr, uint8_t pin,
+                       uint8_t pupd)
+{
+    set_reg_value(gpioX_pupdr, pupd, 0x3 << (2 * pin), 2 * pin);
+}
+
+void soc_gpio_set_od(volatile uint32_t * gpioX_odr, uint8_t pin, uint8_t od)
+{
+    set_reg_value(gpioX_odr, od, 1 << pin, pin);
+}
+
+void soc_gpio_set_bsr_r(volatile uint32_t * gpioX_bsrr_r, uint8_t pin,
+                        uint8_t reset)
+{
+    set_reg_value(gpioX_bsrr_r, reset, 1 << pin, pin);
+}
+
+void soc_gpio_set_bsr_s(volatile uint32_t * gpioX_bsrr_r, uint8_t pin,
+                        uint8_t set)
+{
+    set_reg_value(gpioX_bsrr_r, set, 1 << pin, pin);
+}
+
+void soc_gpio_set_lck(volatile uint32_t * gpioX_lckr, uint8_t pin,
+                      uint8_t value)
+{
+    set_reg_value(gpioX_lckr, value, 1 << pin, pin);
+}
+
+void soc_gpio_set_afr(volatile uint32_t * gpioX_afr, uint8_t pin,
+                      uint8_t function)
+{
+    if (pin > 7)
+        set_reg_value(gpioX_afr + 1, function, 0xf << (4 * (pin - 8)),
+                      4 * (pin - 8));
+    else
+        set_reg_value(gpioX_afr, function, 0xf << (4 * pin), 4 * pin);
+}
+
+#define GPIO_RELEASE(port) \
+		clear_reg_bits(r_CORTEX_M_RCC_AHB1ENR, RCC_AHB1ENR_GPIO##port##EN);
+
+#define GPIO_CONFIG(port) \
+		set_reg_bits(r_CORTEX_M_RCC_AHB1ENR, RCC_AHB1ENR_GPIO##port##EN);\
+		gpioX_moder = GPIO_MODER(GPIO##port##_BASE);\
+		gpioX_otyper = GPIO_OTYPER(GPIO##port##_BASE);\
+		gpioX_ospeedr = GPIO_OSPEEDR(GPIO##port##_BASE);\
+		gpioX_pupdr = GPIO_PUPDR(GPIO##port##_BASE);\
+		gpioX_idr = GPIO_IDR(GPIO##port##_BASE); \
+		gpioX_odr = GPIO_ODR(GPIO##port##_BASE);\
+		gpioX_bsrr_r = GPIO_BSRR_R(GPIO##port##_BASE);\
+		gpioX_bsrr_s = GPIO_BSRR_S(GPIO##port##_BASE);\
+		gpioX_lckr = GPIO_LCKR(GPIO##port##_BASE);\
+		gpioX_afr_l = GPIO_AFR_L(GPIO##port##_BASE);\
+		gpioX_afr_h = GPIO_AFR_H(GPIO##port##_BASE)
+
+uint8_t soc_gpio_release(const dev_gpio_info_t * gpio)
+{
+    physaddr_t portaddr = soc_gpio_get_port_base(gpio->kref);
+
+    /* Does the port exist? */
+    if (portaddr == 0) {
+        return 1;
+    }
+
+    switch (portaddr) {
+        case GPIOA_BASE: GPIO_RELEASE(A); break;
+        case GPIOB_BASE: GPIO_RELEASE(B); break;
+        case GPIOC_BASE: GPIO_RELEASE(C); break;
+        case GPIOD_BASE: GPIO_RELEASE(D); break;
+        case GPIOE_BASE: GPIO_RELEASE(E); break;
+        case GPIOF_BASE: GPIO_RELEASE(F); break;
+        case GPIOG_BASE: GPIO_RELEASE(G); break;
+        case GPIOH_BASE: GPIO_RELEASE(H); break;
+        case GPIOI_BASE: GPIO_RELEASE(I); break;
+        default:
+            return 1;
+    }
+
+    return 0;
+}
+
+uint8_t soc_gpio_set_config(const dev_gpio_info_t * gpio)
+{
+    volatile uint32_t  *gpioX_moder,   *gpioX_otyper,  *gpioX_ospeedr,
+                       *gpioX_pupdr,   *gpioX_idr,     *gpioX_odr,
+                       *gpioX_bsrr_r,  *gpioX_bsrr_s,  *gpioX_lckr,
+                       *gpioX_afr_l, *gpioX_afr_h;
+
+    physaddr_t portaddr = soc_gpio_get_port_base(gpio->kref);
+
+    /* Does the port exist? */
+    if (portaddr == 0) {
+        return 1;
+    }
+
+    switch (portaddr) {
+        case GPIOA_BASE: GPIO_CONFIG(A); break;
+        case GPIOB_BASE: GPIO_CONFIG(B); break;
+        case GPIOC_BASE: GPIO_CONFIG(C); break;
+        case GPIOD_BASE: GPIO_CONFIG(D); break;
+        case GPIOE_BASE: GPIO_CONFIG(E); break;
+        case GPIOF_BASE: GPIO_CONFIG(F); break;
+        case GPIOG_BASE: GPIO_CONFIG(G); break;
+        case GPIOH_BASE: GPIO_CONFIG(H); break;
+        case GPIOI_BASE: GPIO_CONFIG(I); break;
+        default:
+            return 1;
+    }
+
+    /* Set the appropriate values according to the mask */
+    if (gpio->mask & GPIO_MASK_SET_MODE) {
+        soc_gpio_set_mode(gpioX_moder, gpio->kref.pin, gpio->mode);
+    }
+    if (gpio->mask & GPIO_MASK_SET_TYPE) {
+        soc_gpio_set_type(gpioX_otyper, gpio->kref.pin, gpio->type);
+    }
+    if (gpio->mask & GPIO_MASK_SET_SPEED) {
+        soc_gpio_set_speed(gpioX_ospeedr, gpio->kref.pin, gpio->speed);
+    }
+    if (gpio->mask & GPIO_MASK_SET_PUPD) {
+        soc_gpio_set_pupd(gpioX_pupdr, gpio->kref.pin, gpio->pupd);
+    }
+    if (gpio->mask & GPIO_MASK_SET_BSR_R) {
+        soc_gpio_set_bsr_r(gpioX_bsrr_r, gpio->kref.pin, gpio->bsr_r);
+    }
+    if (gpio->mask & GPIO_MASK_SET_BSR_S) {
+        soc_gpio_set_bsr_s(gpioX_bsrr_r, gpio->kref.pin, gpio->bsr_s);
+    }
+    if (gpio->mask & GPIO_MASK_SET_LCK) {
+        soc_gpio_set_lck(gpioX_lckr, gpio->kref.pin, gpio->lck);
+    }
+    if (gpio->mask & GPIO_MASK_SET_AFR) {
+        soc_gpio_set_afr(gpioX_afr_l, gpio->kref.pin, gpio->afr);
+    }
+
+    return 0;
+}
+
+uint8_t soc_gpio_configure
+    (uint8_t port, uint8_t pin, gpio_mode_t mode, gpio_type_t type,
+     gpio_speed_t speed, gpio_pupd_t pupd, gpio_af_t afr)
+{
+    volatile uint32_t  *gpioX_moder,   *gpioX_otyper,  *gpioX_ospeedr,
+                       *gpioX_pupdr,   *gpioX_idr,     *gpioX_odr,
+                       *gpioX_bsrr_r,  *gpioX_bsrr_s,  *gpioX_lckr,
+                       *gpioX_afr_l, *gpioX_afr_h;
+
+    switch (port) {
+        case GPIO_PA: GPIO_CONFIG(A); break;
+        case GPIO_PB: GPIO_CONFIG(B); break;
+        case GPIO_PC: GPIO_CONFIG(C); break;
+        case GPIO_PD: GPIO_CONFIG(D); break;
+        case GPIO_PE: GPIO_CONFIG(E); break;
+        case GPIO_PF: GPIO_CONFIG(F); break;
+        case GPIO_PG: GPIO_CONFIG(G); break;
+        case GPIO_PH: GPIO_CONFIG(H); break;
+        case GPIO_PI: GPIO_CONFIG(I); break;
+        default:
+            return 1;
+    }
+
+    soc_gpio_set_mode(gpioX_moder, pin, mode);
+    soc_gpio_set_type(gpioX_otyper, pin, type);
+    soc_gpio_set_speed(gpioX_ospeedr, pin, speed);
+    soc_gpio_set_pupd(gpioX_pupdr, pin, pupd);
+    soc_gpio_set_afr(gpioX_afr_l, pin, afr);
+
+    return 0;
+}
+
+void soc_gpio_set_value(gpioref_t kref, uint8_t value)
+{
+    physaddr_t portaddr = soc_gpio_get_port_base(kref);
+    soc_gpio_set_od(GPIO_ODR(portaddr), kref.pin, !!value);
+}
+
+uint8_t soc_gpio_get(gpioref_t kref)
+{
+    physaddr_t portaddr = soc_gpio_get_port_base(kref);
+    return !!get_reg_value(GPIO_IDR(portaddr), 1 << (kref.pin), kref.pin);
+}

--- a/src/arch/socs/stm32f439/soc-gpio.c
+++ b/src/arch/socs/stm32f439/soc-gpio.c
@@ -1,24 +1,35 @@
-/* \file soc-gpio.c
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #include "types.h"
 #include "gpio.h"

--- a/src/arch/socs/stm32f439/soc-gpio.h
+++ b/src/arch/socs/stm32f439/soc-gpio.h
@@ -1,0 +1,372 @@
+/* \file soc-gpio.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef SOC_GPIO_H
+#define SOC_GPIO_H
+
+#include "regutils.h"
+#include "soc-core.h"
+#include "soc-rcc.h"
+#include "gpio.h"
+
+#define GPIO_MODER(g)         REG_ADDR((g) + 0x00)    /*!< GPIO port mode register                      */
+#define GPIO_OTYPER(g)        REG_ADDR((g) + 0x04)    /*!< GPIO port output type register               */
+#define GPIO_OSPEEDR(g)       REG_ADDR((g) + 0x08)    /*!< GPIO port output speed register              */
+#define GPIO_PUPDR(g)         REG_ADDR((g) + 0x0C)    /*!< GPIO port pull-up/pull-down register         */
+#define GPIO_IDR(g)           REG_ADDR((g) + 0x10)    /*!< GPIO port input data register                */
+#define GPIO_ODR(g)           REG_ADDR((g) + 0x14)    /*!< GPIO port output data register               */
+#define GPIO_BSRR_R(g)        REG_ADDR((g) + 0x18)    /*!< GPIO port bit set/reset reset register       */
+#define GPIO_BSRR_S(g)        REG_ADDR((g) + 0x1A)    /*!< GPIO port bit set/reset set register         */
+#define GPIO_LCKR(g)          REG_ADDR((g) + 0x1C)    /*!< GPIO port configuration lock register        */
+#define GPIO_AFR_L(g)         REG_ADDR((g) + 0x20)    /*!< GPIO alternate function registers, low part */
+#define GPIO_AFR_H(g)         REG_ADDR((g) + 0x24)    /*!< GPIO alternate function registers, high part  */
+
+#define GPIOA                 REG_ADDR(GPIOA_BASE)
+#define GPIOA_MODER           GPIO_MODER(GPIOA_BASE)
+#define GPIOA_OTYPER          GPIO_OTYPER(GPIOA_BASE)
+#define GPIOA_OSPEEDR         GPIO_OSPEEDR(GPIOA_BASE)
+#define GPIOA_PUPDR           GPIO_PUPDR(GPIOA_BASE)
+#define GPIOA_IDR             GPIO_IDR(GPIOA_BASE)
+#define GPIOA_ODR             GPIO_ODR(GPIOA_BASE)
+#define GPIOA_BSRR_R          GPIO_BSRR_R(GPIOA_BASE)
+#define GPIOA_BSRR_S          GPIO_BSRR_S(GPIOA_BASE)
+#define GPIOA_LCKR            GPIO_LCKR(GPIOA_BASE)
+#define GPIOA_AFR_L           GPIO_AFR_L(GPIOA_BASE)
+#define GPIOA_AFR_H           GPIO_AFR_H(GPIOA_BASE)
+
+#define GPIOB                 REG_ADDR(GPIOB_BASE)
+#define GPIOB_MODER           GPIO_MODER(GPIOB_BASE)
+#define GPIOB_OTYPER          GPIO_OTYPER(GPIOB_BASE)
+#define GPIOB_OSPEEDR         GPIO_OSPEEDR(GPIOB_BASE)
+#define GPIOB_PUPDR           GPIO_PUPDR(GPIOB_BASE)
+#define GPIOB_IDR             GPIO_IDR(GPIOB_BASE)
+#define GPIOB_ODR             GPIO_ODR(GPIOB_BASE)
+#define GPIOB_BSRR_R          GPIO_BSRR_R(GPIOB_BASE)
+#define GPIOB_BSRR_S          GPIO_BSRR_S(GPIOB_BASE)
+#define GPIOB_LCKR            GPIO_LCKR(GPIOB_BASE)
+#define GPIOB_AFR_L           GPIO_AFR_L(GPIOB_BASE)
+#define GPIOB_AFR_H           GPIO_AFR_H(GPIOB_BASE)
+
+#define GPIOC                 REG_ADDR(GPIOC_BASE)
+#define GPIOC_MODER           GPIO_MODER(GPIOC_BASE)
+#define GPIOC_OTYPER          GPIO_OTYPER(GPIOC_BASE)
+#define GPIOC_OSPEEDR         GPIO_OSPEEDR(GPIOC_BASE)
+#define GPIOC_PUPDR           GPIO_PUPDR(GPIOC_BASE)
+#define GPIOC_IDR             GPIO_IDR(GPIOC_BASE)
+#define GPIOC_ODR             GPIO_ODR(GPIOC_BASE)
+#define GPIOC_BSRR_R          GPIO_BSRR_R(GPIOC_BASE)
+#define GPIOC_BSRR_S          GPIO_BSRR_S(GPIOC_BASE)
+#define GPIOC_LCKR            GPIO_LCKR(GPIOC_BASE)
+#define GPIOC_AFR_L           GPIO_AFR_L(GPIOC_BASE)
+#define GPIOC_AFR_H           GPIO_AFR_H(GPIOC_BASE)
+
+#define GPIOD                 REG_ADDR(GPIOD_BASE)
+#define GPIOD_MODER           GPIO_MODER(GPIOD_BASE)
+#define GPIOD_OTYPER          GPIO_OTYPER(GPIOD_BASE)
+#define GPIOD_OSPEEDR         GPIO_OSPEEDR(GPIOD_BASE)
+#define GPIOD_PUPDR           GPIO_PUPDR(GPIOD_BASE)
+#define GPIOD_IDR             GPIO_IDR(GPIOD_BASE)
+#define GPIOD_ODR             GPIO_ODR(GPIOD_BASE)
+#define GPIOD_BSRR_R          GPIO_BSRR_R(GPIOD_BASE)
+#define GPIOD_BSRR_S          GPIO_BSRR_S(GPIOD_BASE)
+#define GPIOD_LCKR            GPIO_LCKR(GPIOD_BASE)
+#define GPIOD_AFR_L           GPIO_AFR_L(GPIOD_BASE)
+#define GPIOD_AFR_H           GPIO_AFR_H(GPIOD_BASE)
+
+#define GPIOE                 REG_ADDR(GPIOE_BASE)
+#define GPIOE_MODER           GPIO_MODER(GPIOE_BASE)
+#define GPIOE_OTYPER          GPIO_OTYPER(GPIOE_BASE)
+#define GPIOE_OSPEEDR         GPIO_OSPEEDR(GPIOE_BASE)
+#define GPIOE_PUPDR           GPIO_PUPDR(GPIOE_BASE)
+#define GPIOE_IDR             GPIO_IDR(GPIOE_BASE)
+#define GPIOE_ODR             GPIO_ODR(GPIOE_BASE)
+#define GPIOE_BSRR_R          GPIO_BSRR_R(GPIOE_BASE)
+#define GPIOE_BSRR_S          GPIO_BSRR_S(GPIOE_BASE)
+#define GPIOE_LCKR            GPIO_LCKR(GPIOE_BASE)
+#define GPIOE_AFR_L           GPIO_AFR_L(GPIOE_BASE)
+#define GPIOE_AFR_H           GPIO_AFR_H(GPIOE_BASE)
+
+#define GPIOF                 REG_ADDR(GPIOF_BASE)
+#define GPIOF_MODER           GPIO_MODER(GPIOF_BASE)
+#define GPIOF_OTYPER          GPIO_OTYPER(GPIOF_BASE)
+#define GPIOF_OSPEEDR         GPIO_OSPEEDR(GPIOF_BASE)
+#define GPIOF_PUPDR           GPIO_PUPDR(GPIOF_BASE)
+#define GPIOF_IDR             GPIO_IDR(GPIOF_BASE)
+#define GPIOF_ODR             GPIO_ODR(GPIOF_BASE)
+#define GPIOF_BSRR_R          GPIO_BSRR_R(GPIOF_BASE)
+#define GPIOF_BSRR_S          GPIO_BSRR_S(GPIOF_BASE)
+#define GPIOF_LCKR            GPIO_LCKR(GPIOF_BASE)
+#define GPIOF_AFR_L           GPIO_AFR_L(GPIOF_BASE)
+#define GPIOF_AFR_H           GPIO_AFR_H(GPIOF_BASE)
+
+#define GPIOG                 REG_ADDR(GPIOG_BASE)
+#define GPIOG_MODER           GPIO_MODER(GPIOG_BASE)
+#define GPIOG_OTYPER          GPIO_OTYPER(GPIOG_BASE)
+#define GPIOG_OSPEEDR         GPIO_OSPEEDR(GPIOG_BASE)
+#define GPIOG_PUPDR           GPIO_PUPDR(GPIOG_BASE)
+#define GPIOG_IDR             GPIO_IDR(GPIOG_BASE)
+#define GPIOG_ODR             GPIO_ODR(GPIOG_BASE)
+#define GPIOG_BSRR_R          GPIO_BSRR_R(GPIOG_BASE)
+#define GPIOG_BSRR_S          GPIO_BSRR_S(GPIOG_BASE)
+#define GPIOG_LCKR            GPIO_LCKR(GPIOG_BASE)
+#define GPIOG_AFR_L           GPIO_AFR_L(GPIOG_BASE)
+#define GPIOG_AFR_H           GPIO_AFR_H(GPIOG_BASE)
+
+#define GPIOH                 REG_ADDR(GPIOH_BASE)
+#define GPIOH_MODER           GPIO_MODER(GPIOH_BASE)
+#define GPIOH_OTYPER          GPIO_OTYPER(GPIOH_BASE)
+#define GPIOH_OSPEEDR         GPIO_OSPEEDR(GPIOH_BASE)
+#define GPIOH_PUPDR           GPIO_PUPDR(GPIOH_BASE)
+#define GPIOH_IDR             GPIO_IDR(GPIOH_BASE)
+#define GPIOH_ODR             GPIO_ODR(GPIOH_BASE)
+#define GPIOH_BSRR_R          GPIO_BSRR_R(GPIOH_BASE)
+#define GPIOH_BSRR_S          GPIO_BSRR_S(GPIOH_BASE)
+#define GPIOH_LCKR            GPIO_LCKR(GPIOH_BASE)
+#define GPIOH_AFR_L           GPIO_AFR_L(GPIOH_BASE)
+#define GPIOH_AFR_H           GPIO_AFR_H(GPIOH_BASE)
+
+#define GPIOI                 REG_ADDR(GPIOI_BASE)
+#define GPIOI_MODER           GPIO_MODER(GPIOI_BASE)
+#define GPIOI_OTYPER          GPIO_OTYPER(GPIOI_BASE)
+#define GPIOI_OSPEEDR         GPIO_OSPEEDR(GPIOI_BASE)
+#define GPIOI_PUPDR           GPIO_PUPDR(GPIOI_BASE)
+#define GPIOI_IDR             GPIO_IDR(GPIOI_BASE)
+#define GPIOI_ODR             GPIO_ODR(GPIOI_BASE)
+#define GPIOI_BSRR_R          GPIO_BSRR_R(GPIOI_BASE)
+#define GPIOI_BSRR_S          GPIO_BSRR_S(GPIOI_BASE)
+#define GPIOI_LCKR            GPIO_LCKR(GPIOI_BASE)
+#define GPIOI_AFR_L           GPIO_AFR_L(GPIOI_BASE)
+#define GPIOI_AFR_H           GPIO_AFR_H(GPIOI_BASE)
+
+#define GPIO_PIN_0            ((uint16_t)0x0001)
+#define GPIO_PIN_1            ((uint16_t)0x0002)
+#define GPIO_PIN_2            ((uint16_t)0x0004)
+#define GPIO_PIN_3            ((uint16_t)0x0008)
+#define GPIO_PIN_4            ((uint16_t)0x0010)
+#define GPIO_PIN_5            ((uint16_t)0x0020)
+#define GPIO_PIN_6            ((uint16_t)0x0040)
+#define GPIO_PIN_7            ((uint16_t)0x0080)
+#define GPIO_PIN_8            ((uint16_t)0x0100)
+#define GPIO_PIN_9            ((uint16_t)0x0200)
+#define GPIO_PIN_10           ((uint16_t)0x0400)
+#define GPIO_PIN_11           ((uint16_t)0x0800)
+#define GPIO_PIN_12           ((uint16_t)0x1000)
+#define GPIO_PIN_13           ((uint16_t)0x2000)
+#define GPIO_PIN_14           ((uint16_t)0x4000)
+#define GPIO_PIN_15           ((uint16_t)0x8000)
+#define GPIO_PIN_ALL          ((uint16_t)0xFFFF)
+
+/* RESET VALUES REGISTERS */
+#define GPIOA_MODER_RESET     ((uint32_t)0xA8000000)
+#define GPIOB_MODER_RESET     ((uint32_t)0x00000280)
+#define GPIOC_MODER_RESET     ((uint32_t)0x00000000)
+#define GPIOD_MODER_RESET     ((uint32_t)0x00000000)
+#define GPIOE_MODER_RESET     ((uint32_t)0x00000000)
+#define GPIOF_MODER_RESET     ((uint32_t)0x00000000)
+#define GPIOG_MODER_RESET     ((uint32_t)0x00000000)
+#define GPIOH_MODER_RESET     ((uint32_t)0x00000000)
+#define GPIOI_MODER_RESET     ((uint32_t)0x00000000)
+
+#define GPIOA_OTYPER_RESET    ((uint32_t)0x00000000)
+#define GPIOB_OTYPER_RESET    ((uint32_t)0x00000000)
+#define GPIOC_OTYPER_RESET    ((uint32_t)0x00000000)
+#define GPIOD_OTYPER_RESET    ((uint32_t)0x00000000)
+#define GPIOE_OTYPER_RESET    ((uint32_t)0x00000000)
+#define GPIOF_OTYPER_RESET    ((uint32_t)0x00000000)
+#define GPIOG_OTYPER_RESET    ((uint32_t)0x00000000)
+#define GPIOH_OTYPER_RESET    ((uint32_t)0x00000000)
+#define GPIOI_OTYPER_RESET    ((uint32_t)0x00000000)
+
+#define GPIOA_OSPEEDER_RESET  ((uint32_t)0x0C000000)
+#define GPIOB_OSPEEDER_RESET  ((uint32_t)0x000000C0)
+#define GPIOC_OSPEEDER_RESET  ((uint32_t)0x00000000)
+#define GPIOD_OSPEEDER_RESET  ((uint32_t)0x00000000)
+#define GPIOE_OSPEEDER_RESET  ((uint32_t)0x00000000)
+#define GPIOF_OSPEEDER_RESET  ((uint32_t)0x00000000)
+#define GPIOG_OSPEEDER_RESET  ((uint32_t)0x00000000)
+#define GPIOH_OSPEEDER_RESET  ((uint32_t)0x00000000)
+#define GPIOI_OSPEEDER_RESET  ((uint32_t)0x00000000)
+
+#define GPIOA_PUPDR_RESET     ((uint32_t)0x64000000)
+#define GPIOB_PUPDR_RESET     ((uint32_t)0x00000100)
+#define GPIOC_PUPDR_RESET     ((uint32_t)0x00000000)
+#define GPIOD_PUPDR_RESET     ((uint32_t)0x00000000)
+#define GPIOE_PUPDR_RESET     ((uint32_t)0x00000000)
+#define GPIOF_PUPDR_RESET     ((uint32_t)0x00000000)
+#define GPIOG_PUPDR_RESET     ((uint32_t)0x00000000)
+#define GPIOH_PUPDR_RESET     ((uint32_t)0x00000000)
+#define GPIOI_PUPDR_RESET     ((uint32_t)0x00000000)
+
+#define GPIOA_ODR_RESET       ((uint32_t)0x00000000)
+#define GPIOB_ODR_RESET       ((uint32_t)0x00000000)
+#define GPIOC_ODR_RESET       ((uint32_t)0x00000000)
+#define GPIOD_ODR_RESET       ((uint32_t)0x00000000)
+#define GPIOE_ODR_RESET       ((uint32_t)0x00000000)
+#define GPIOF_ODR_RESET       ((uint32_t)0x00000000)
+#define GPIOG_ODR_RESET       ((uint32_t)0x00000000)
+#define GPIOH_ODR_RESET       ((uint32_t)0x00000000)
+#define GPIOI_ODR_RESET       ((uint32_t)0x00000000)
+
+#define GPIOA_BSRR_RESET      ((uint32_t)0x00000000)
+#define GPIOB_BSRR_RESET      ((uint32_t)0x00000000)
+#define GPIOC_BSRR_RESET      ((uint32_t)0x00000000)
+#define GPIOD_BSRR_RESET      ((uint32_t)0x00000000)
+#define GPIOE_BSRR_RESET      ((uint32_t)0x00000000)
+#define GPIOF_BSRR_RESET      ((uint32_t)0x00000000)
+#define GPIOG_BSRR_RESET      ((uint32_t)0x00000000)
+#define GPIOH_BSRR_RESET      ((uint32_t)0x00000000)
+#define GPIOI_BSSR_RESET      ((uint32_t)0x00000000)
+
+#define GPIOA_LCKR_RESET      ((uint32_t)0x00000000)
+#define GPIOB_LCKR_RESET      ((uint32_t)0x00000000)
+#define GPIOC_LCKR_RESET      ((uint32_t)0x00000000)
+#define GPIOD_LCKR_RESET      ((uint32_t)0x00000000)
+#define GPIOE_LCKR_RESET      ((uint32_t)0x00000000)
+#define GPIOF_LCKR_RESET      ((uint32_t)0x00000000)
+#define GPIOG_LCKR_RESET      ((uint32_t)0x00000000)
+#define GPIOH_LCKR_RESET      ((uint32_t)0x00000000)
+#define GPIOI_LCKR_RESET      ((uint32_t)0x00000000)
+
+#define GPIOA_AFRL_RESET      ((uint32_t)0x00000000)
+#define GPIOB_AFRL_RESET      ((uint32_t)0x00000000)
+#define GPIOC_AFRL_RESET      ((uint32_t)0x00000000)
+#define GPIOD_AFRL_RESET      ((uint32_t)0x00000000)
+#define GPIOE_AFRL_RESET      ((uint32_t)0x00000000)
+#define GPIOF_AFRL_RESET      ((uint32_t)0x00000000)
+#define GPIOG_AFRL_RESET      ((uint32_t)0x00000000)
+#define GPIOH_AFRL_RESET      ((uint32_t)0x00000000)
+#define GPIOI_AFRL_RESET      ((uint32_t)0x00000000)
+
+#define GPIOA_AFRH_RESET      ((uint32_t)0x00000000)
+#define GPIOB_AFRH_RESET      ((uint32_t)0x00000000)
+#define GPIOC_AFRH_RESET      ((uint32_t)0x00000000)
+#define GPIOD_AFRH_RESET      ((uint32_t)0x00000000)
+#define GPIOE_AFRH_RESET      ((uint32_t)0x00000000)
+#define GPIOF_AFRH_RESET      ((uint32_t)0x00000000)
+#define GPIOG_AFRH_RESET      ((uint32_t)0x00000000)
+#define GPIOH_AFRH_RESET      ((uint32_t)0x00000000)
+#define GPIOI_AFRH_RESET      ((uint32_t)0x00000000)
+
+/* Definition of the alternate functions used
+ * for GPIOs. See Figure 14 "Selecting an alternate function"
+ * in the datasheet.
+ */
+/* AF0 (system) */
+#define GPIO_AF_AF0            0x0
+#define GPIO_AF_SYSTEM         GPIO_AF_AF0
+/* AF1 (TIM1/TIM2) */
+#define GPIO_AF_AF1            0x1
+#define GPIO_AF_TIM1           GPIO_AF_AF1
+#define GPIO_AF_TIM2           GPIO_AF_AF1
+/* AF2 (TIM3..5) */
+#define GPIO_AF_AF2            0x2
+#define GPIO_AF_TIM3           GPIO_AF_AF2
+#define GPIO_AF_TIM4           GPIO_AF_AF2
+#define GPIO_AF_TIM5           GPIO_AF_AF2
+/* AF3 (TIM8..11) */
+#define GPIO_AF_AF3            0x3
+#define GPIO_AF_TIM8           GPIO_AF_AF3
+#define GPIO_AF_TIM9           GPIO_AF_AF3
+#define GPIO_AF_TIM10          GPIO_AF_AF3
+#define GPIO_AF_TIM11          GPIO_AF_AF3
+/* AF4 (I2C1..3) */
+#define GPIO_AF_AF4            0x4
+#define GPIO_AF_I2C1           GPIO_AF_AF4
+#define GPIO_AF_I2C2           GPIO_AF_AF4
+#define GPIO_AF_I2C3           GPIO_AF_AF4
+/* AF5 (SPI1/SPI2) */
+#define GPIO_AF_AF5            0x5
+#define GPIO_AF_SPI1           GPIO_AF_AF5
+#define GPIO_AF_SPI2           GPIO_AF_AF5
+/* AF6 (SPI3) */
+#define GPIO_AF_AF6            0x6
+#define GPIO_AF_SPI3           GPIO_AF_AF6
+/* AF7 (USART1..3) */
+#define GPIO_AF_AF7            0x7
+#define GPIO_AF_USART1         GPIO_AF_AF7
+#define GPIO_AF_USART2         GPIO_AF_AF7
+#define GPIO_AF_USART3         GPIO_AF_AF7
+/* AF8 (USART4..6) */
+#define GPIO_AF_AF8            0x8
+#define GPIO_AF_USART4         GPIO_AF_AF8
+#define GPIO_AF_UART4          GPIO_AF_AF8
+#define GPIO_AF_USART5         GPIO_AF_AF8
+#define GPIO_AF_UART5          GPIO_AF_AF8
+#define GPIO_AF_USART6         GPIO_AF_AF8
+/* AF9 (CAN1/CAN2, TIM12..14) */
+#define GPIO_AF_AF9            0x9
+#define GPIO_AF_CAN1           GPIO_AF_AF9
+#define GPIO_AF_CAN2           GPIO_AF_AF9
+#define GPIO_AF_TIM12          GPIO_AF_AF9
+#define GPIO_AF_TIM13          GPIO_AF_AF9
+#define GPIO_AF_TIM14          GPIO_AF_AF9
+/* AF10 (OTG_FS, OTG_HS) */
+#define GPIO_AF_AF10           0xa
+#define GPIO_AF_OTG_FS         GPIO_AF_AF10
+#define GPIO_AF_OTG_HS         GPIO_AF_AF10
+/* AF11 (ETH) */
+#define GPIO_AF_AF11           0xb
+#define GPIO_AF_ETH            GPIO_AF_AF11
+/* AF12 (FSMC, SDIO, OTG_HS_FS) */
+#define GPIO_AF_AF12           0xc
+#define GPIO_AF_FSMC           GPIO_AF_AF12
+#define GPIO_AF_SDIO           GPIO_AF_AF12
+#define GPIO_AF_OTG_HS_FS      GPIO_AF_AF12
+/* AF13 (DCMI) */
+#define GPIO_AF_AF13           0xd
+#define GPIO_AF_DCMI           GPIO_AF_AF13
+/* AF14 */
+#define GPIO_AF_AF14           0xe
+/* AF15 (EVENTOUT) */
+#define GPIO_AF_AF15           0xf
+#define GPIO_AF_EVENTOUT       GPIO_AF_AF15
+
+/*
+ * Configure a GPIO given an associated structure, including
+ * a configuration mask
+ */
+uint8_t soc_gpio_set_config(const dev_gpio_info_t * gpio);
+
+/*
+ * Relaese the GPIO, including deactivating the RCC clock
+ */
+uint8_t soc_gpio_release(const dev_gpio_info_t * gpio);
+
+uint8_t soc_gpio_configure
+    (uint8_t port, uint8_t pin,
+     gpio_mode_t mode,
+     gpio_type_t type,
+     gpio_speed_t speed,
+     gpio_pupd_t pupd,
+     gpio_af_t afr);
+
+/*
+ * GPIO value accessors (set, get, clear)
+ */
+void    soc_gpio_set_value(gpioref_t   kref,
+                           uint8_t   value);
+
+uint8_t soc_gpio_get(gpioref_t   kref);
+
+bool soc_gpio_exists(gpioref_t kref);
+
+#endif/*!SOC_GPIO_H */

--- a/src/arch/socs/stm32f439/soc-gpio.h
+++ b/src/arch/socs/stm32f439/soc-gpio.h
@@ -1,24 +1,35 @@
-/* \file soc-gpio.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef SOC_GPIO_H
 #define SOC_GPIO_H

--- a/src/arch/socs/stm32f439/soc-init.c
+++ b/src/arch/socs/stm32f439/soc-init.c
@@ -1,24 +1,35 @@
-/* \file soc-init.c
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #include "autoconf.h"
 #include "m4-cpu.h"

--- a/src/arch/socs/stm32f439/soc-init.c
+++ b/src/arch/socs/stm32f439/soc-init.c
@@ -1,0 +1,82 @@
+/* \file soc-init.c
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#include "autoconf.h"
+#include "m4-cpu.h"
+#include "soc-init.h"
+#include "soc-flash.h"
+#include "soc-pwr.h"
+#include "soc-scb.h"
+#include "soc-rcc.h"
+#include "debug.h"
+
+/*
+ * \brief Configure the Vector Table location and offset address
+ *
+ * WARNING : No interrupts here => IRQs disabled
+ *				=> No LOGs here
+ */
+void set_vtor(uint32_t addr)
+{
+
+    __DMB();                    /* Data Memory Barrier */
+#ifdef CONFIG_STM32F4
+    write_reg_value(r_CORTEX_M_SCB_VTOR, addr);
+#endif
+    __DSB();                    /*
+                                 * Data Synchronization Barrier to ensure all
+                                 * subsequent instructions use the new configuration
+                                 */
+}
+
+/* void system_init(void)
+ * \brief  Setup the microcontroller system
+ *
+ *         Initialize the Embedded Flash Interface, the PLL and update the
+ *         SystemFrequency variable.
+ */
+void system_init(uint32_t addr)
+{
+#ifdef PROD_ENABLE_HSE
+    bool enable_hse = true;
+#else
+    bool enable_hse = false;
+#endif
+
+#ifdef PROD_ENABLE_PLL
+    bool enable_pll = true;
+#else
+    bool enable_hse = false;
+#endif
+
+#ifdef CONFIG_STM32F4
+    soc_rcc_reset();
+    /*
+     * Configure the System clock source, PLL Multiplier and Divider factors,
+     * AHB/APBx prescalers and Flash settings
+     */
+    soc_rcc_setsysclock(enable_hse, enable_pll);
+#endif
+
+    //set_vtor(FLASH_BASE|VECT_TAB_OFFSET);
+    set_vtor(addr);
+}

--- a/src/arch/socs/stm32f439/soc-init.h
+++ b/src/arch/socs/stm32f439/soc-init.h
@@ -1,24 +1,35 @@
-/* \file soc-init.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef SOC_INIT_H
 #define SOC_INIT_H

--- a/src/arch/socs/stm32f439/soc-init.h
+++ b/src/arch/socs/stm32f439/soc-init.h
@@ -1,0 +1,65 @@
+/* \file soc-init.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef SOC_INIT_H
+#define SOC_INIT_H
+
+#include "types.h"
+#include "soc-rcc.h"
+
+#define RESET	0
+#define SET	1
+
+#if !defined (HSE_STARTUP_TIMEOUT)
+#define HSE_STARTUP_TIMEOUT	((uint16_t)0x0500)
+#endif                          /* !HSE_STARTUP_TIMEOUT */
+
+#if !defined (HSI_STARTUP_TIMEOUT)
+#define HSI_STARTUP_TIMEOUT	((uint16_t)0x0500)
+#endif                          /* !HSI_STARTUP_TIMEOUT */
+
+#define STM32F429
+
+//#define PROD_ENABLE_HSE
+#define PROD_ENABLE_PLL 1
+
+#define PROD_PLL_M     16
+#define PROD_PLL_N     336
+#define PROD_PLL_P     2
+#define PROD_PLL_Q     7
+
+#define PROD_HCLK      RCC_CFGR_HPRE_DIV1
+#define PROD_PCLK2     RCC_CFGR_HPRE2_DIV2
+#define PROD_PCLK1     RCC_CFGR_HPRE1_DIV4
+
+#define PROD_CLOCK_APB1  42000000 // MHz
+#define PROD_CLOCK_APB2  84000000 // MHz
+
+#define PROD_CORE_FREQUENCY 168000
+
+#define LDR_BASE 0x08000000
+#define VTORS_SIZE 0x188
+
+void set_vtor(uint32_t);
+void system_init(uint32_t);
+
+#endif/*!SOC_INIT_H*/

--- a/src/arch/socs/stm32f439/soc-interrupts.h
+++ b/src/arch/socs/stm32f439/soc-interrupts.h
@@ -1,0 +1,145 @@
+/* \file soc_irq.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef SOC_IRQ_
+#define SOC_IRQ_
+
+#include "types.h"
+
+/*
+** That structure points to the saved registers on the caller
+** (mostly a user task) stack.
+*/
+
+typedef struct {
+    uint32_t r4, r5, r6, r7, r8, r9, r10, r11, lr;
+    uint32_t r0, r1, r2, r3, r12, prev_lr, pc, xpsr;
+} __attribute__ ((packed)) stack_frame_t;
+
+/*
+** This permit the bellowing table to be used by a given IRQ handler
+** e.g. s_irq[USART1_IRQ].fn give the custom handler pointer if it exists
+*/
+typedef enum {
+    ESTACK = 0,
+    RESET_IRQ,
+    NMI_IRQ,
+    HARDFAULT_IRQ,
+    MEMMANAGE_IRQ,
+    BUSFAULT_IRQ,
+    USAGEFAULT_IRQ,
+    VOID1_IRQ,
+    VOID2_IRQ,
+    VOID3_IRQ,
+    VOID4_IRQ,
+    SVC_IRQ,
+    DEBUGON_IRQ,
+    VOID5_IRQ,
+    PENDSV_IRQ,
+    SYSTICK_IRQ,
+    WWDG_IRQ,
+    PVD_IRQ,
+    TAMP_STAMP_IRQ,
+    RTC_WKUP_IRQ,
+    FLASH_IRQ,
+    RCC_IRQ,
+    EXTI0_IRQ,
+    EXTI1_IRQ,
+    EXTI2_IRQ,
+    EXTI3_IRQ,
+    EXTI4_IRQ,
+    DMA1_Stream0_IRQ,
+    DMA1_Stream1_IRQ,
+    DMA1_Stream2_IRQ,
+    DMA1_Stream3_IRQ,
+    DMA1_Stream4_IRQ,
+    DMA1_Stream5_IRQ,
+    DMA1_Stream6_IRQ,
+    ADC_IRQ,
+    CAN1_TX_IRQ,
+    CAN1_RX0_IRQ,
+    CAN1_RX1_IRQ,
+    CAN1_SCE_IRQ,
+    EXTI9_5_IRQ,
+    TIM1_BRK_TIM9_IRQ,
+    TIM1_UP_TIM10_IRQ,
+    TIM1_TRG_COM_TIM11_IRQ,
+    TIM1_CC_IRQ,
+    TIM2_IRQ,
+    TIM3_IRQ,
+    TIM4_IRQ,
+    I2C1_EV_IRQ,
+    I2C1_ER_IRQ,
+    I2C2_EV_IRQ,
+    I2C2_ER_IRQ,
+    SPI1_IRQ,
+    SPI2_IRQ,
+    USART1_IRQ,
+    USART2_IRQ,
+    USART3_IRQ,
+    EXTI15_10_IRQ,
+    RTC_Alarm_IRQ,
+    OTG_FS_WKUP_IRQ,
+    TIM8_BRK_TIM12_IRQ,
+    TIM8_UP_TIM13_IRQ,
+    TIM8_TRG_COM_TIM14_IRQ,
+    TIM8_CC_IRQ,
+    DMA1_Stream7_IRQ,
+    FSMC_IRQ,
+    SDIO_IRQ,
+    TIM5_IRQ,
+    SPI3_IRQ,
+    UART4_IRQ,
+    UART5_IRQ,
+    TIM6_DAC_IRQ,
+    TIM7_IRQ,
+    DMA2_Stream0_IRQ,
+    DMA2_Stream1_IRQ,
+    DMA2_Stream2_IRQ,
+    DMA2_Stream3_IRQ,
+    DMA2_Stream4_IRQ,
+    ETH_IRQ,
+    ETH_WKUP_IRQ,
+    CAN2_TX_IRQ,
+    CAN2_RX0_IRQ,
+    CAN2_RX1_IRQ,
+    CAN2_SCE_IRQ,
+    OTG_FS_IRQ,
+    DMA2_Stream5_IRQ,
+    DMA2_Stream6_IRQ,
+    DMA2_Stream7_IRQ,
+    USART6_IRQ,
+    I2C3_EV_IRQ,
+    I2C3_ER_IRQ,
+    OTG_HS_EP1_OUT_IRQ,
+    OTG_HS_EP1_IN_IRQ,
+    OTG_HS_WKUP_IRQ,
+    OTG_HS_IRQ,
+    DCMI_IRQ,
+    CRYP_IRQ,
+    HASH_RNG_IRQ,
+    FPU_IRQ,
+} e_irq_id;
+
+
+
+#endif /*!SOC_IRQ_ */

--- a/src/arch/socs/stm32f439/soc-interrupts.h
+++ b/src/arch/socs/stm32f439/soc-interrupts.h
@@ -1,24 +1,35 @@
-/* \file soc_irq.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef SOC_IRQ_
 #define SOC_IRQ_

--- a/src/arch/socs/stm32f439/soc-nvic.h
+++ b/src/arch/socs/stm32f439/soc-nvic.h
@@ -1,0 +1,246 @@
+/* \file soc-nvic.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef SOC_NVIC_H
+#define SOC_NVIC_H
+
+#include "m4-cpu.h"
+#include "soc-core.h"
+#include "soc-scb.h"
+
+/*
+ * NVIC register block is 0xE000E100. The NVIC_STIR register is located in a separate block at 0xE000EF00.
+ *
+ * The NVIC supports:
+ * • Up to 81 interrupts (interrupt number depends on the STM32 device type;
+ *   refer to the datasheets)
+ *
+ * • A programmable priority level of 0-15 for each interrupt.
+ *   A higher level corresponds to a lower priority, so level 0 is the highest interrupt priority
+ *
+ * • Level and pulse detection of interrupt signals
+ *
+ * • Dynamic reprioritization of interrupts
+ *
+ * • Grouping of priority values into group priority and subpriority fields
+ *
+ * • Interrupt tail-chaining
+ *
+ * • An external Non-maskable interrupt (NMI)
+ *
+ * The processor automatically stacks its state on exception entry and unstacks this state on
+ * exception exit, with no instruction overhead.
+ */
+
+/* 0xE000E100-0xE000E10B NVIC_ISER0-NVIC_ISER2 (RW Privileged) Interrupt set-enable registers */
+#define r_CORTEX_M_NVIC_ISER0   REG_ADDR(NVIC_BASE + (uint32_t)0x00)
+#define r_CORTEX_M_NVIC_ISER1   REG_ADDR(NVIC_BASE + (uint32_t)0x04)
+#define r_CORTEX_M_NVIC_ISER2   REG_ADDR(NVIC_BASE + (uint32_t)0x08)
+/* 0XE000E180-0xE000E18B NVIC_ICER0-NVIC_ICER2 (RW Privileged) Interrupt clear-enable registers */
+#define r_CORTEX_M_NVIC_ICER0   REG_ADDR(NVIC_BASE + (uint32_t)0x80)
+#define r_CORTEX_M_NVIC_ICER1   REG_ADDR(NVIC_BASE + (uint32_t)0x84)
+#define r_CORTEX_M_NVIC_ICER2   REG_ADDR(NVIC_BASE + (uint32_t)0x88)
+/* 0XE000E200-0xE000E20B NVIC_ISPR0-NVIC_ISPR2 (RW Privileged) Interrupt set-pending registers */
+#define r_CORTEX_M_NVIC_ISPR0   REG_ADDR(NVIC_BASE + (uint32_t)0x100)
+#define r_CORTEX_M_NVIC_ISPR1   REG_ADDR(NVIC_BASE + (uint32_t)0x104)
+#define r_CORTEX_M_NVIC_ISPR2   REG_ADDR(NVIC_BASE + (uint32_t)0x108)
+/* 0XE000E280-0xE000E29C NVIC_ICPR0-NVIC_ICPR2 (RW Privileged) Interrupt clear-pending registers */
+#define r_CORTEX_M_NVIC_ICPR0   REG_ADDR(NVIC_BASE + (uint32_t)0x180)
+#define r_CORTEX_M_NVIC_ICPR1   REG_ADDR(NVIC_BASE + (uint32_t)0x184)
+#define r_CORTEX_M_NVIC_ICPR2   REG_ADDR(NVIC_BASE + (uint32_t)0x188)
+/* 0xE000E300-0xE000E31C NVIC_IABR0-NVIC_IABR2 (RW Privileged) Interrupt active bit registers */
+#define r_CORTEX_M_NVIC_IABR0   REG_ADDR(NVIC_BASE + (uint32_t)0x200)
+#define r_CORTEX_M_NVIC_IABR1   REG_ADDR(NVIC_BASE + (uint32_t)0x204)
+#define r_CORTEX_M_NVIC_IABR2   REG_ADDR(NVIC_BASE + (uint32_t)0x208)
+/* 0xE000E400-0xE000E503 NVIC_IPR0-NVIC_IPR20  (RW Privileged)Interrupt priority registers */
+#define r_CORTEX_M_NVIC_IPR0    REG_ADDR(NVIC_BASE + (uint32_t)0x300)
+#define r_CORTEX_M_NVIC_IPR1    REG_ADDR(NVIC_BASE + (uint32_t)0x301)
+#define r_CORTEX_M_NVIC_IPR2    REG_ADDR(NVIC_BASE + (uint32_t)0x302)
+#define r_CORTEX_M_NVIC_IPR3    REG_ADDR(NVIC_BASE + (uint32_t)0x303)
+#define r_CORTEX_M_NVIC_IPR4    REG_ADDR(NVIC_BASE + (uint32_t)0x304)
+#define r_CORTEX_M_NVIC_IPR5    REG_ADDR(NVIC_BASE + (uint32_t)0x305)
+#define r_CORTEX_M_NVIC_IPR6    REG_ADDR(NVIC_BASE + (uint32_t)0x306)
+#define r_CORTEX_M_NVIC_IPR7    REG_ADDR(NVIC_BASE + (uint32_t)0x307)
+#define r_CORTEX_M_NVIC_IPR8    REG_ADDR(NVIC_BASE + (uint32_t)0x308)
+#define r_CORTEX_M_NVIC_IPR9    REG_ADDR(NVIC_BASE + (uint32_t)0x309)
+#define r_CORTEX_M_NVIC_IPR10   REG_ADDR(NVIC_BASE + (uint32_t)0x310)
+#define r_CORTEX_M_NVIC_IPR11   REG_ADDR(NVIC_BASE + (uint32_t)0x311)
+#define r_CORTEX_M_NVIC_IPR12   REG_ADDR(NVIC_BASE + (uint32_t)0x312)
+#define r_CORTEX_M_NVIC_IPR13   REG_ADDR(NVIC_BASE + (uint32_t)0x313)
+#define r_CORTEX_M_NVIC_IPR14   REG_ADDR(NVIC_BASE + (uint32_t)0x314)
+#define r_CORTEX_M_NVIC_IPR15   REG_ADDR(NVIC_BASE + (uint32_t)0x315)
+#define r_CORTEX_M_NVIC_IPR16   REG_ADDR(NVIC_BASE + (uint32_t)0x316)
+#define r_CORTEX_M_NVIC_IPR17   REG_ADDR(NVIC_BASE + (uint32_t)0x317)
+#define r_CORTEX_M_NVIC_IPR18   REG_ADDR(NVIC_BASE + (uint32_t)0x318)
+#define r_CORTEX_M_NVIC_IPR19   REG_ADDR(NVIC_BASE + (uint32_t)0x310)
+#define r_CORTEX_M_NVIC_IPR20   REG_ADDR(NVIC_BASE + (uint32_t)0x320)
+#define r_CORTEX_M_NIVIC_STIR   REG_ADDR(NVIC_STIR_BASE)    /* 0xE000EF00 (WO Configurable) Software trigger interrupt register */
+
+/* Interrupt set-enable registers (NVIC_ISERx) */
+#define NVIC_ISER_SETENA  REG_ADDR(r_CORTEX_M_NVIC_ISER0)
+
+/* Interrupt clear-enable registers (NVIC_ICERx) */
+#define NVIC_ICER  REG_ADDR(r_CORTEX_M_NVIC_ICER0)
+
+/* Interrupt set-pending registers (NVIC_ISPRx) */
+#define NVIC_ISPR  REG_ADDR(r_CORTEX_M_NVIC_ISPR0)
+
+/* Interrupt clear-pending registers (NVIC_ICPRx) */
+#define NVIC_ICPR  REG_ADDR(r_CORTEX_M_NVIC_ICPR0)
+
+/* Interrupt active bit registers (NVIC_IABRx) */
+#define NVIC_IABR  REG_ADDR(r_CORTEX_M_NVIC_IABR0)
+
+/* Interrupt priority registers (NVIC_IPRx) */
+#define NVIC_IPR   REG_ADDR(r_CORTEX_M_NVIC_IPR0)
+
+/* Software trigger interrupt register (NVIC_STIR) */
+#define NVIC_STIR  REG_ADDR(r_CORTEX_M_NIVIC_STIR)
+
+/* Interrupt set-enable registers */
+#define NVIC_ISER   REG_ADDR(r_CORTEX_M_NVIC_ISER0)
+
+/* ##########################   NVIC functions  #################################### */
+/* \ingroup  CMSIS_Core_FunctionInterface
+ * \defgroup CMSIS_Core_NVICFunctions CMSIS Core NVIC Functions
+ * @{
+ */
+
+/* \brief  Set Priority Grouping
+ * This function sets the priority grouping field using the required unlock sequence.
+ * The parameter PriorityGroup is assigned to the field SCB_AIRCR [10:8] PRIGROUP field.
+ * Only values from 0..7 are used.
+ * In case of a conflict between priority grouping and available
+ * priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+ * \param [in]      PriorityGroup  Priority grouping field
+ */
+__INLINE void NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+    uint32_t reg_value;
+    uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t) 0x07);  /* only values 0..7 are used          */
+
+    reg_value = *r_CORTEX_M_SCB_AIRCR;  /* read old register configuration    */
+    reg_value &= ~(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk); /* clear bits to change               */
+    /* Insert write key and priority group */
+    reg_value =
+        (reg_value | ((uint32_t) 0x5FA << SCB_AIRCR_VECTKEY_Pos) |
+         (PriorityGroupTmp << 8));
+    *r_CORTEX_M_SCB_AIRCR = reg_value;
+}
+
+/* \brief  Get Priority Grouping
+ * This function gets the priority grouping from NVIC Interrupt Controller.
+ * Priority grouping is SCB->AIRCR [10:8] PRIGROUP field.
+ * \return                Priority grouping field
+ */
+__INLINE uint32_t NVIC_GetPriorityGrouping(void)
+{
+    return ((*r_CORTEX_M_SCB_AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos);    /* read priority grouping field */
+}
+
+/* \brief  Enable External Interrupt
+ * This function enables a device specific interrupt in the NVIC interrupt controller.
+ * The interrupt number cannot be a negative value.
+ * \param [in]      IRQn  Number of the external interrupt to enable
+ */
+__INLINE void NVIC_EnableIRQ(uint32_t IRQn)
+{
+    /*  NVIC->ISER[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F));  enable interrupt */
+    NVIC_ISER[(uint32_t) ((int32_t) IRQn) >> 5] =
+        (uint32_t) (1 << ((uint32_t) ((int32_t) IRQn) & (uint32_t) 0x1F));
+}
+
+/* \brief  Disable External Interrupt
+ * This function disables a device specific interrupt in the NVIC interrupt controller.
+ * The interrupt number cannot be a negative value.
+ * \param [in]      IRQn  Number of the external interrupt to disable
+ */
+__INLINE void NVIC_DisableIRQ(uint32_t IRQn)
+{
+    NVIC_ICER[((uint32_t) (IRQn) >> 5)] = (uint32_t) (1 << ((uint32_t) (IRQn) & 0x1F)); /* disable interrupt */
+}
+
+/* \brief  Get Pending Interrupt
+ * This function reads the pending register in the NVIC and returns the pending bit
+ * for the specified interrupt.
+ * \param [in]      IRQn  Number of the interrupt for get pending
+ * \return             0  Interrupt status is not pending
+ * \return             1  Interrupt status is pending
+ */
+__INLINE uint32_t NVIC_GetPendingIRQ(uint32_t IRQn)
+{
+    /* Return 1 if pending else 0 */
+    return ((uint32_t)
+            ((NVIC_ISPR[(uint32_t) (IRQn) >> 5] &
+              (uint32_t) (1 << ((uint32_t) (IRQn) & 0x1F))) ? 1 : 0));
+}
+
+/* \brief  Set Pending Interrupt
+ *
+ * This function sets the pending bit for the specified interrupt.
+ * The interrupt number cannot be a negative value.
+ * \param [in]      IRQn  Number of the interrupt for set pending
+ */
+__INLINE void NVIC_SetPendingIRQ(uint32_t IRQn)
+{
+    NVIC_ISPR[((uint32_t) (IRQn) >> 5)] = (uint32_t) (1 << ((uint32_t) (IRQn) & 0x1F)); /* set interrupt pending */
+}
+
+/* \brief  Clear Pending Interrupt
+ * This function clears the pending bit for the specified interrupt.
+ * The interrupt number cannot be a negative value.
+ * \param [in]      IRQn  Number of the interrupt for clear pending
+ */
+__INLINE void NVIC_ClearPendingIRQ(uint32_t IRQn)
+{
+    NVIC_ICPR[((uint32_t) (IRQn) >> 5)] = (uint32_t) (1 << ((uint32_t) (IRQn) & 0x1F)); /* Clear pending interrupt */
+}
+
+/* \brief  Get Active Interrupt
+ * This function reads the active register in NVIC and returns the active bit.
+ * \param [in]      IRQn  Number of the interrupt for get active
+ * \return             0  Interrupt status is not active
+ * \return             1  Interrupt status is active
+ */
+__INLINE uint32_t NVIC_GetActive(uint32_t IRQn)
+{
+    /* Return 1 if active else 0 */
+    return ((uint32_t)
+            ((NVIC_IABR[(uint32_t) (IRQn) >> 5] &
+              (uint32_t) (1 << ((uint32_t) (IRQn) & 0x1F))) ? 1 : 0));
+}
+
+/* \brief  System Reset
+ * This function initiate a system reset request to reset the MCU.
+ */
+__INLINE void NVIC_SystemReset(void)
+{
+    __DSB();                    /* Ensure all outstanding memory accesses included buffered write are completed before reset */
+    *r_CORTEX_M_SCB_AIRCR = ((0x5FA << SCB_AIRCR_VECTKEY_Pos) | (*r_CORTEX_M_SCB_AIRCR & SCB_AIRCR_PRIGROUP_Msk) | SCB_AIRCR_SYSRESETREQ_Msk);  /* Keep priority group unchanged */
+    __DSB();                    /* Ensure completion of memory access */
+    while (1)
+        continue;               /* wait until reset */
+}
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+#endif /*!SOC_NVIC_H */

--- a/src/arch/socs/stm32f439/soc-nvic.h
+++ b/src/arch/socs/stm32f439/soc-nvic.h
@@ -1,24 +1,35 @@
-/* \file soc-nvic.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef SOC_NVIC_H
 #define SOC_NVIC_H

--- a/src/arch/socs/stm32f439/soc-pwr.h
+++ b/src/arch/socs/stm32f439/soc-pwr.h
@@ -1,24 +1,35 @@
-/* \file soc-pwr.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef SOC_PWR_H
 #define SOC_PWR_H

--- a/src/arch/socs/stm32f439/soc-pwr.h
+++ b/src/arch/socs/stm32f439/soc-pwr.h
@@ -1,0 +1,80 @@
+/* \file soc-pwr.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef SOC_PWR_H
+#define SOC_PWR_H
+
+#include "soc-core.h"
+
+/*
+ * These registers are defined for STM32F405xx/407xx and STM32F415xx/417xx
+ * only. Please refer to the programming manual section 5.5 for STM32F42xxx and
+ * STM32F43xxx).
+ */
+#define r_CORTEX_M_PWR_CR	REG_ADDR(PWR_BASE + 0x00)
+#define r_CORTEX_M_PWR_CSR	REG_ADDR(PWR_BASE + 0x04)
+
+/* Power control register */
+#define PWR_CR_LPDS_Pos		0
+#define PWR_CR_LPDS_Msk		((uint32_t)1 << PWR_CR_LPDS_Pos)
+#define PWR_CR_PDDS_Pos		1
+#define PWR_CR_PDDS_Msk		((uint32_t)1 << PWR_CR_PDDS_Pos)
+#define PWR_CR_CWUF_Pos		2
+#define PWR_CR_CWUF_Msk		((uint32_t)1 << PWR_CR_CWUF_Pos)
+#define PWR_CR_CSBF_Pos		3
+#define PWR_CR_CSBF_Msk		((uint32_t)1 << PWR_CR_CSBF_Pos)
+#define PWR_CR_PVDE_Pos		4
+#define PWR_CR_PVDE_Msk		((uint32_t)1 << PWR_CR_PVDE_Pos)
+#define PWR_CR_PLS_Pos			5
+#define PWR_CR_PLS_Msk			((uint32_t)7 << PWR_CR_PLS_Pos)
+#	define PWR_CR_PLS_2_0V			0
+#	define PWR_CR_PLS_2_1V			1
+#	define PWR_CR_PLS_2_3V			2
+#	define PWR_CR_PLS_2_5V			3
+#	define PWR_CR_PLS_2_6V			4
+#	define PWR_CR_PLS_2_7V			5
+#	define PWR_CR_PLS_2_8V			6
+#	define PWR_CR_PLS_2_9V			7
+#define PWR_CR_DBP_Pos			8
+#define PWR_CR_DBP_Msk			((uint32_t)1 << PWR_CR_DBP_Pos)
+#define PWR_CR_FPDS_Pos		9
+#define PWR_CR_FPDS_Msk		((uint32_t)1 << PWR_CR_FPDS_Pos)
+#define PWR_CR_VOS_Pos			14
+#define PWR_CR_VOS_Msk			((uint32_t)1 << PWR_CR_VOS_Pos)
+
+/* Power control/status register */
+#define PWR_CSR_WUF_Pos		0
+#define PWR_CSR_WUF_Msk		((uint32_t)1 << PWR_CSR_WUF_Pos)
+#define PWR_CSR_SBF_Pos		1
+#define PWR_CSR_SBF_Msk		((uint32_t)1 << PWR_CSR_SBF_Pos)
+#define PWR_CSR_PVDO_Pos		2
+#define PWR_CSR_PVDO_Msk		((uint32_t)1 << PWR_CSR_PVDO_Pos)
+#define PWR_CSR_BRR_Pos		3
+#define PWR_CSR_BRR_Msk		((uint32_t)1 << PWR_CSR_BRR_Pos)
+#define PWR_CSR_EWUP_Pos		8
+#define PWR_CSR_EWUP_Msk		((uint32_t)1 << PWR_CSR_EWUP_Pos)
+#define PWR_CSR_BRE_Pos		9
+#define PWR_CSR_BRE_Msk		((uint32_t)1 << PWR_CSR_BRE_Pos)
+#define PWR_CSR_VOSRDY_Pos		14
+#define PWR_CSR_VOSRDY_Msk		((uint32_t)1 << PWR_CSR_VOSRDY_Pos)
+
+#endif /*!SOC_PWR_H */

--- a/src/arch/socs/stm32f439/soc-rcc.c
+++ b/src/arch/socs/stm32f439/soc-rcc.c
@@ -1,24 +1,35 @@
-/* \file soc-rcc.c
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #include "regutils.h"
 #include "autoconf.h"

--- a/src/arch/socs/stm32f439/soc-rcc.c
+++ b/src/arch/socs/stm32f439/soc-rcc.c
@@ -1,0 +1,141 @@
+/* \file soc-rcc.c
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#include "regutils.h"
+#include "autoconf.h"
+#include "soc-rcc.h"
+#include "soc-pwr.h"
+#include "soc-flash.h"
+#include "m4-cpu.h"
+
+/*
+ * TODO: some of the bellowing code should be M4 generic. Yet, check if all
+ * these registers are M4 generic or STM32F4 core specific
+ */
+void soc_rcc_reset(void)
+{
+    /* Reset the RCC clock configuration to the default reset state */
+    /* Set HSION bit */
+    set_reg_bits(r_CORTEX_M_RCC_CR, RCC_CR_HSION);
+
+    /* Reset CFGR register */
+    write_reg_value(r_CORTEX_M_RCC_CFGR, 0x00000000);
+
+    /* Reset HSEON, CSSON and PLLON bits */
+    clear_reg_bits(r_CORTEX_M_RCC_CR,
+                   RCC_CR_HSEON | RCC_CR_CSSON | RCC_CR_PLLON);
+
+    /* Reset PLLCFGR register */
+    write_reg_value(r_CORTEX_M_RCC_PLLCFGR, 0x24003010);
+
+    /* Reset HSEBYP bit */
+    clear_reg_bits(r_CORTEX_M_RCC_CR, RCC_CR_HSEBYP);
+
+    /* Reset all interrupts */
+    write_reg_value(r_CORTEX_M_RCC_CIR, 0x00000000);
+
+    full_memory_barrier();
+}
+
+void soc_rcc_setsysclock(bool enable_hse, bool enable_pll)
+{
+    uint32_t StartUpCounter = 0, status = 0;
+
+    /*
+     * PLL (clocked by HSE/HSI) used as System clock source
+     */
+
+    if (enable_hse) {
+        /* Enable HSE */
+        set_reg_bits(r_CORTEX_M_RCC_CR, RCC_CR_HSEON);
+        do {
+            status = read_reg_value(r_CORTEX_M_RCC_CR) & RCC_CR_HSERDY;
+            StartUpCounter++;
+        } while ((status == 0) && (StartUpCounter != HSE_STARTUP_TIMEOUT));
+    } else {
+        /* Enable HSI */
+        set_reg_bits(r_CORTEX_M_RCC_CR, RCC_CR_HSION);
+        do {
+            status = read_reg_value(r_CORTEX_M_RCC_CR) & RCC_CR_HSIRDY;
+            StartUpCounter++;
+        } while ((status == 0) && (StartUpCounter != HSI_STARTUP_TIMEOUT));
+    }
+
+    if (status != RESET) {
+        /* Enable high performance mode, System frequency up to 168 MHz */
+        set_reg_bits(r_CORTEX_M_RCC_APB1ENR, RCC_APB1ENR_PWREN);
+        /*
+         * This bit controls the main internal voltage regulator output
+         * voltage to achieve a trade-off between performance and power
+         * consumption when the device does not operate at the maximum
+         * frequency. (DocID018909 Rev 15 - page 141)
+         * PWR_CR_VOS = 1 => Scale 1 mode (default value at reset)
+         */
+        set_reg_bits(r_CORTEX_M_PWR_CR, PWR_CR_VOS_Msk);
+
+        /* Set clock dividers */
+        set_reg_bits(r_CORTEX_M_RCC_CFGR, PROD_HCLK);
+        set_reg_bits(r_CORTEX_M_RCC_CFGR, PROD_PCLK2);
+        set_reg_bits(r_CORTEX_M_RCC_CFGR, PROD_PCLK1);
+
+        if (enable_pll) {
+            /* Configure the main PLL */
+            if (enable_hse) {
+                write_reg_value(r_CORTEX_M_RCC_PLLCFGR, PROD_PLL_M | (PROD_PLL_N << 6)
+                    | (((PROD_PLL_P >> 1) - 1) << 16)
+                    | (RCC_PLLCFGR_PLLSRC_HSE) | (PROD_PLL_Q << 24));
+            } else {
+                write_reg_value(r_CORTEX_M_RCC_PLLCFGR, PROD_PLL_M | (PROD_PLL_N << 6)
+                    | (((PROD_PLL_P >> 1) - 1) << 16)
+                    | (RCC_PLLCFGR_PLLSRC_HSI) | (PROD_PLL_Q << 24));
+            }
+
+            /* Enable the main PLL */
+            set_reg_bits(r_CORTEX_M_RCC_CR, RCC_CR_PLLON);
+
+            /* Wait till the main PLL is ready */
+            while ((read_reg_value(r_CORTEX_M_RCC_CR) & RCC_CR_PLLRDY) == 0)
+                continue;
+        }
+
+        /* Configure Flash prefetch, Instruction cache, Data cache and wait state */
+        write_reg_value(r_CORTEX_M_FLASH_ACR, FLASH_ACR_ICEN
+                        | FLASH_ACR_DCEN | FLASH_ACR_LATENCY_5WS);
+
+        if (enable_pll) {
+            /* Select the main PLL as system clock source */
+            clear_reg_bits(r_CORTEX_M_RCC_CFGR, RCC_CFGR_SW);
+            set_reg_bits(r_CORTEX_M_RCC_CFGR, RCC_CFGR_SW_PLL);
+
+            /* Wait till the main PLL is used as system clock source */
+            while ((read_reg_value(r_CORTEX_M_RCC_CFGR) & (uint32_t) RCC_CFGR_SWS)
+                    != RCC_CFGR_SWS_PLL)
+                continue;
+        }
+
+    } else {
+        /* If HSE/I fails to start-up, the application will have wrong
+         * clock configuration. User can add here some code to deal
+         * with this error.
+         */
+    }
+}

--- a/src/arch/socs/stm32f439/soc-rcc.h
+++ b/src/arch/socs/stm32f439/soc-rcc.h
@@ -1,0 +1,751 @@
+/* \file soc-rcc.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef SOC_RCC_H
+#define SOC_RCC_H
+
+#include "soc-init.h"
+#include "soc-core.h"
+
+#define r_CORTEX_M_RCC_CR           REG_ADDR(RCC_BASE + (uint32_t) 0x00)
+#define r_CORTEX_M_RCC_PLLCFGR      REG_ADDR(RCC_BASE + (uint32_t) 0x04)
+#define r_CORTEX_M_RCC_CFGR         REG_ADDR(RCC_BASE + (uint32_t) 0x08)
+#define r_CORTEX_M_RCC_CIR          REG_ADDR(RCC_BASE + (uint32_t) 0x0C)
+#define r_CORTEX_M_RCC_AHB1RSTR     REG_ADDR(RCC_BASE + (uint32_t) 0x10)
+#define r_CORTEX_M_RCC_AHB2RSTR     REG_ADDR(RCC_BASE + (uint32_t) 0x14)
+#define r_CORTEX_M_RCC_AHB3RSTR     REG_ADDR(RCC_BASE + (uint32_t) 0x18)
+#define r_CORTEX_M_RCC_APB1RSTR     REG_ADDR(RCC_BASE + (uint32_t) 0x20)
+#define r_CORTEX_M_RCC_APB2RSTR     REG_ADDR(RCC_BASE + (uint32_t) 0x24)
+#define r_CORTEX_M_RCC_AHB1ENR      REG_ADDR(RCC_BASE + (uint32_t) 0x30)
+#define r_CORTEX_M_RCC_AHB2ENR      REG_ADDR(RCC_BASE + (uint32_t) 0x34)
+#define r_CORTEX_M_RCC_AHB3ENR      REG_ADDR(RCC_BASE + (uint32_t) 0x38)
+#define r_CORTEX_M_RCC_APB1ENR      REG_ADDR(RCC_BASE + (uint32_t) 0x40)
+#define r_CORTEX_M_RCC_APB2ENR      REG_ADDR(RCC_BASE + (uint32_t) 0x44)
+#define r_CORTEX_M_RCC_AHB1LPENR    REG_ADDR(RCC_BASE + (uint32_t) 0x50)
+#define r_CORTEX_M_RCC_AHB2LPENR    REG_ADDR(RCC_BASE + (uint32_t) 0x54)
+#define r_CORTEX_M_RCC_AHB3LPENR    REG_ADDR(RCC_BASE + (uint32_t) 0x58)
+#define r_CORTEX_M_RCC_APB1LPENR    REG_ADDR(RCC_BASE + (uint32_t) 0x60)
+#define r_CORTEX_M_RCC_APB2LPENR    REG_ADDR(RCC_BASE + (uint32_t) 0x64)
+#define r_CORTEX_M_RCC_BDCR         REG_ADDR(RCC_BASE + (uint32_t) 0x70)
+#define r_CORTEX_M_RCC_CSR          REG_ADDR(RCC_BASE + (uint32_t) 0x74)
+#define r_CORTEX_M_RCC_SSCGR        REG_ADDR(RCC_BASE + (uint32_t) 0x80)
+#define r_CORTEX_M_RCC_PLLI2SCFGR   REG_ADDR(RCC_BASE + (uint32_t) 0x84)
+#define r_CORTEX_M_RCC_PLLSAICFGR   REG_ADDR(RCC_BASE + (uint32_t) 0x88)
+#define r_CORTEX_M_RCC_DCKCFGR      REG_ADDR(RCC_BASE + (uint32_t) 0x8C)
+
+/* RCC clock control register (RCC_CR) */
+#define  RCC_CR_HSION                        ((uint32_t) 0x00000001)
+#define  RCC_CR_HSIRDY                       ((uint32_t) 0x00000002)
+
+#define  RCC_CR_HSITRIM                      ((uint32_t) 0x000000F8)
+#define  RCC_CR_HSITRIM_0                    ((uint32_t) 0x00000008)    /*Bit 0 */
+#define  RCC_CR_HSITRIM_1                    ((uint32_t) 0x00000010)    /*Bit 1 */
+#define  RCC_CR_HSITRIM_2                    ((uint32_t) 0x00000020)    /*Bit 2 */
+#define  RCC_CR_HSITRIM_3                    ((uint32_t) 0x00000040)    /*Bit 3 */
+#define  RCC_CR_HSITRIM_4                    ((uint32_t) 0x00000080)    /*Bit 4 */
+
+#define  RCC_CR_HSICAL                       ((uint32_t) 0x0000FF00)
+#define  RCC_CR_HSICAL_0                     ((uint32_t) 0x00000100)    /*Bit 0 */
+#define  RCC_CR_HSICAL_1                     ((uint32_t) 0x00000200)    /*Bit 1 */
+#define  RCC_CR_HSICAL_2                     ((uint32_t) 0x00000400)    /*Bit 2 */
+#define  RCC_CR_HSICAL_3                     ((uint32_t) 0x00000800)    /*Bit 3 */
+#define  RCC_CR_HSICAL_4                     ((uint32_t) 0x00001000)    /*Bit 4 */
+#define  RCC_CR_HSICAL_5                     ((uint32_t) 0x00002000)    /*Bit 5 */
+#define  RCC_CR_HSICAL_6                     ((uint32_t) 0x00004000)    /*Bit 6 */
+#define  RCC_CR_HSICAL_7                     ((uint32_t) 0x00008000)    /*Bit 7 */
+
+#define  RCC_CR_HSEON                        ((uint32_t) 0x00010000)
+#define  RCC_CR_HSERDY                       ((uint32_t) 0x00020000)
+#define  RCC_CR_HSEBYP                       ((uint32_t) 0x00040000)
+#define  RCC_CR_CSSON                        ((uint32_t) 0x00080000)
+#define  RCC_CR_PLLON                        ((uint32_t) 0x01000000)
+#define  RCC_CR_PLLRDY                       ((uint32_t) 0x02000000)
+#define  RCC_CR_PLLI2SON                     ((uint32_t) 0x04000000)
+#define  RCC_CR_PLLI2SRDY                    ((uint32_t) 0x08000000)
+
+/* RCC PLL configuration register (RCC_PLLCFGR) */
+#define  RCC_PLLCFGR_PLLM                    ((uint32_t) 0x0000003F)
+#define  RCC_PLLCFGR_PLLM_0                  ((uint32_t) 0x00000001)
+#define  RCC_PLLCFGR_PLLM_1                  ((uint32_t) 0x00000002)
+#define  RCC_PLLCFGR_PLLM_2                  ((uint32_t) 0x00000004)
+#define  RCC_PLLCFGR_PLLM_3                  ((uint32_t) 0x00000008)
+#define  RCC_PLLCFGR_PLLM_4                  ((uint32_t) 0x00000010)
+#define  RCC_PLLCFGR_PLLM_5                  ((uint32_t) 0x00000020)
+
+#define  RCC_PLLCFGR_PLLN                     ((uint32_t) 0x00007FC0)
+#define  RCC_PLLCFGR_PLLN_0                   ((uint32_t) 0x00000040)
+#define  RCC_PLLCFGR_PLLN_1                   ((uint32_t) 0x00000080)
+#define  RCC_PLLCFGR_PLLN_2                   ((uint32_t) 0x00000100)
+#define  RCC_PLLCFGR_PLLN_3                   ((uint32_t) 0x00000200)
+#define  RCC_PLLCFGR_PLLN_4                   ((uint32_t) 0x00000400)
+#define  RCC_PLLCFGR_PLLN_5                   ((uint32_t) 0x00000800)
+#define  RCC_PLLCFGR_PLLN_6                   ((uint32_t) 0x00001000)
+#define  RCC_PLLCFGR_PLLN_7                   ((uint32_t) 0x00002000)
+#define  RCC_PLLCFGR_PLLN_8                   ((uint32_t) 0x00004000)
+
+#define  RCC_PLLCFGR_PLLP                    ((uint32_t) 0x00030000)
+#define  RCC_PLLCFGR_PLLP_0                  ((uint32_t) 0x00010000)
+#define  RCC_PLLCFGR_PLLP_1                  ((uint32_t) 0x00020000)
+
+#define  RCC_PLLCFGR_PLLSRC                  ((uint32_t) 0x00400000)
+#define  RCC_PLLCFGR_PLLSRC_HSE              ((uint32_t) 0x00400000)
+#define  RCC_PLLCFGR_PLLSRC_HSI              ((uint32_t) 0x00000000)
+
+#define  RCC_PLLCFGR_PLLQ                    ((uint32_t) 0x0F000000)
+#define  RCC_PLLCFGR_PLLQ_0                  ((uint32_t) 0x01000000)
+#define  RCC_PLLCFGR_PLLQ_1                  ((uint32_t) 0x02000000)
+#define  RCC_PLLCFGR_PLLQ_2                  ((uint32_t) 0x04000000)
+#define  RCC_PLLCFGR_PLLQ_3                  ((uint32_t) 0x08000000)
+
+/* RCC clock configuration register (RCC_CFGR) */
+#define  RCC_CFGR_SW                         ((uint32_t) 0x00000003)    /* SW[1:0] bits (System clock Switch) */
+#define  RCC_CFGR_SW_0                       ((uint32_t) 0x00000001)    /* Bit 0 */
+#define  RCC_CFGR_SW_1                       ((uint32_t) 0x00000002)    /* Bit 1 */
+
+#define  RCC_CFGR_SW_HSI                     ((uint32_t) 0x00000000)    /* HSI selected as system clock */
+#define  RCC_CFGR_SW_HSE                     ((uint32_t) 0x00000001)    /* HSE selected as system clock */
+#define  RCC_CFGR_SW_PLL                     ((uint32_t) 0x00000002)    /* PLL selected as system clock */
+
+/* SWS configuration */
+#define  RCC_CFGR_SWS                        ((uint32_t) 0x0000000C)    /* SWS[1:0] bits (System Clock Switch Status) */
+#define  RCC_CFGR_SWS_0                      ((uint32_t) 0x00000004)    /* Bit 0 */
+#define  RCC_CFGR_SWS_1                      ((uint32_t) 0x00000008)    /* Bit 1 */
+
+#define  RCC_CFGR_SWS_HSI                    ((uint32_t) 0x00000000)    /* HSI oscillator used as system clock */
+#define  RCC_CFGR_SWS_HSE                    ((uint32_t) 0x00000004)    /* HSE oscillator used as system clock */
+#define  RCC_CFGR_SWS_PLL                    ((uint32_t) 0x00000008)    /* PLL used as system clock */
+
+/* HPRE configuration */
+#define  RCC_CFGR_HPRE                       ((uint32_t) 0x000000F0)    /* HPRE[3:0] bits (AHB prescaler) */
+#define  RCC_CFGR_HPRE_0                     ((uint32_t) 0x00000010)    /* Bit 0 */
+#define  RCC_CFGR_HPRE_1                     ((uint32_t) 0x00000020)    /* Bit 1 */
+#define  RCC_CFGR_HPRE_2                     ((uint32_t) 0x00000040)    /* Bit 2 */
+#define  RCC_CFGR_HPRE_3                     ((uint32_t) 0x00000080)    /* Bit 3 */
+
+#define  RCC_CFGR_HPRE_DIV1                  ((uint32_t) 0x00000000)    /* SYSCLK not divided */
+#define  RCC_CFGR_HPRE_DIV2                  ((uint32_t) 0x00000080)    /* SYSCLK divided by 2 */
+#define  RCC_CFGR_HPRE_DIV4                  ((uint32_t) 0x00000090)    /* SYSCLK divided by 4 */
+#define  RCC_CFGR_HPRE_DIV8                  ((uint32_t) 0x000000A0)    /* SYSCLK divided by 8 */
+#define  RCC_CFGR_HPRE_DIV16                 ((uint32_t) 0x000000B0)    /* SYSCLK divided by 16 */
+#define  RCC_CFGR_HPRE_DIV64                 ((uint32_t) 0x000000C0)    /* SYSCLK divided by 64 */
+#define  RCC_CFGR_HPRE_DIV128                ((uint32_t) 0x000000D0)    /* SYSCLK divided by 128 */
+#define  RCC_CFGR_HPRE_DIV256                ((uint32_t) 0x000000E0)    /* SYSCLK divided by 256 */
+#define  RCC_CFGR_HPRE_DIV512                ((uint32_t) 0x000000F0)    /* SYSCLK divided by 512 */
+
+/* PPRE1 configuration */
+#define  RCC_CFGR_HPRE1                      ((uint32_t) 0x00001C00)    /* PRE1[2:0] bits (APB1 prescaler) */
+#define  RCC_CFGR_HPRE1_0                    ((uint32_t) 0x00000400)    /* Bit 0 */
+#define  RCC_CFGR_HPRE1_1                    ((uint32_t) 0x00000800)    /* Bit 1 */
+#define  RCC_CFGR_HPRE1_2                    ((uint32_t) 0x00001000)    /* Bit 2 */
+
+#define  RCC_CFGR_HPRE1_DIV1                 ((uint32_t) 0x00000000)    /* HCLK not divided */
+#define  RCC_CFGR_HPRE1_DIV2                 ((uint32_t) 0x00001000)    /* HCLK divided by 2 */
+#define  RCC_CFGR_HPRE1_DIV4                 ((uint32_t) 0x00001400)    /* HCLK divided by 4 */
+#define  RCC_CFGR_HPRE1_DIV8                 ((uint32_t) 0x00001800)    /* HCLK divided by 8 */
+#define  RCC_CFGR_HPRE1_DIV16                ((uint32_t) 0x00001C00)    /* HCLK divided by 16 */
+
+/* PPRE2 configuration */
+#define  RCC_CFGR_HPRE2                      ((uint32_t) 0x0000E000)    /* PRE2[2:0] bits (APB2 prescaler) */
+#define  RCC_CFGR_HPRE2_0                    ((uint32_t) 0x00002000)    /* Bit 0 */
+#define  RCC_CFGR_HPRE2_1                    ((uint32_t) 0x00004000)    /* Bit 1 */
+#define  RCC_CFGR_HPRE2_2                    ((uint32_t) 0x00008000)    /* Bit 2 */
+
+#define  RCC_CFGR_HPRE2_DIV1                 ((uint32_t) 0x00000000)    /* HCLK not divided */
+#define  RCC_CFGR_HPRE2_DIV2                 ((uint32_t) 0x00008000)    /* HCLK divided by 2 */
+#define  RCC_CFGR_HPRE2_DIV4                 ((uint32_t) 0x0000A000)    /* HCLK divided by 4 */
+#define  RCC_CFGR_HPRE2_DIV8                 ((uint32_t) 0x0000C000)    /* HCLK divided by 8 */
+#define  RCC_CFGR_HPRE2_DIV16                ((uint32_t) 0x0000E000)    /* HCLK divided by 16 */
+
+/* RTCPRE configuration */
+#define  RCC_CFGR_RTCPRE                     ((uint32_t) 0x001F0000)
+#define  RCC_CFGR_RTCPRE_0                   ((uint32_t) 0x00010000)
+#define  RCC_CFGR_RTCPRE_1                   ((uint32_t) 0x00020000)
+#define  RCC_CFGR_RTCPRE_2                   ((uint32_t) 0x00040000)
+#define  RCC_CFGR_RTCPRE_3                   ((uint32_t) 0x00080000)
+#define  RCC_CFGR_RTCPRE_4                   ((uint32_t) 0x00100000)
+
+/* MCO1 configuration */
+#define  RCC_CFGR_MCO1                       ((uint32_t) 0x00600000)
+#define  RCC_CFGR_MCO1_0                     ((uint32_t) 0x00200000)
+#define  RCC_CFGR_MCO1_1                     ((uint32_t) 0x00400000)
+
+#define  RCC_CFGR_I2SSRC                     ((uint32_t) 0x00800000)
+
+#define  RCC_CFGR_MCO1PRE                    ((uint32_t) 0x07000000)
+#define  RCC_CFGR_MCO1PRE_0                  ((uint32_t) 0x01000000)
+#define  RCC_CFGR_MCO1PRE_1                  ((uint32_t) 0x02000000)
+#define  RCC_CFGR_MCO1PRE_2                  ((uint32_t) 0x04000000)
+
+#define  RCC_CFGR_MCO2PRE                    ((uint32_t) 0x38000000)
+#define  RCC_CFGR_MCO2PRE_0                  ((uint32_t) 0x08000000)
+#define  RCC_CFGR_MCO2PRE_1                  ((uint32_t) 0x10000000)
+#define  RCC_CFGR_MCO2PRE_2                  ((uint32_t) 0x20000000)
+
+#define  RCC_CFGR_MCO2                       ((uint32_t) 0xC0000000)
+#define  RCC_CFGR_MCO2_0                     ((uint32_t) 0x40000000)
+#define  RCC_CFGR_MCO2_1                     ((uint32_t) 0x80000000)
+
+/* RCC clock interrupt register (RCC_CIR) */
+#define  RCC_CIR_LSIRDYF                     ((uint32_t) 0x00000001)
+#define  RCC_CIR_LSERDYF                     ((uint32_t) 0x00000002)
+#define  RCC_CIR_HSIRDYF                     ((uint32_t) 0x00000004)
+#define  RCC_CIR_HSERDYF                     ((uint32_t) 0x00000008)
+#define  RCC_CIR_PLLRDYF                     ((uint32_t) 0x00000010)
+#define  RCC_CIR_PLLI2SRDYF                  ((uint32_t) 0x00000020)
+#define  RCC_CIR_CSSF                        ((uint32_t) 0x00000080)
+#define  RCC_CIR_LSIRDYIE                    ((uint32_t) 0x00000100)
+#define  RCC_CIR_LSERDYIE                    ((uint32_t) 0x00000200)
+#define  RCC_CIR_HSIRDYIE                    ((uint32_t) 0x00000400)
+#define  RCC_CIR_HSERDYIE                    ((uint32_t) 0x00000800)
+#define  RCC_CIR_PLLRDYIE                    ((uint32_t) 0x00001000)
+#define  RCC_CIR_PLLI2SRDYIE                 ((uint32_t) 0x00002000)
+#define  RCC_CIR_LSIRDYC                     ((uint32_t) 0x00010000)
+#define  RCC_CIR_LSERDYC                     ((uint32_t) 0x00020000)
+#define  RCC_CIR_HSIRDYC                     ((uint32_t) 0x00040000)
+#define  RCC_CIR_HSERDYC                     ((uint32_t) 0x00080000)
+#define  RCC_CIR_PLLRDYC                     ((uint32_t) 0x00100000)
+#define  RCC_CIR_PLLI2SRDYC                  ((uint32_t) 0x00200000)
+#define  RCC_CIR_CSSC                        ((uint32_t) 0x00800000)
+
+/* RCC AHB1 peripheral reset register (RCC_AHB1RSTR) */
+#define  RCC_AHB1RSTR_GPIOARST               ((uint32_t) 0x00000001)
+#define  RCC_AHB1RSTR_GPIOBRST               ((uint32_t) 0x00000002)
+#define  RCC_AHB1RSTR_GPIOCRST               ((uint32_t) 0x00000004)
+#define  RCC_AHB1RSTR_GPIODRST               ((uint32_t) 0x00000008)
+#define  RCC_AHB1RSTR_GPIOERST               ((uint32_t) 0x00000010)
+#define  RCC_AHB1RSTR_GPIOFRST               ((uint32_t) 0x00000020)
+#define  RCC_AHB1RSTR_GPIOGRST               ((uint32_t) 0x00000040)
+#define  RCC_AHB1RSTR_GPIOHRST               ((uint32_t) 0x00000080)
+#define  RCC_AHB1RSTR_GPIOIRST               ((uint32_t) 0x00000100)
+#define  RCC_AHB1RSTR_CRCRST                 ((uint32_t) 0x00001000)
+#define  RCC_AHB1RSTR_DMA1RST                ((uint32_t) 0x00200000)
+#define  RCC_AHB1RSTR_DMA2RST                ((uint32_t) 0x00400000)
+#define  RCC_AHB1RSTR_ETHMACRST              ((uint32_t) 0x02000000)
+#define  RCC_AHB1RSTR_OTGHRST                ((uint32_t) 0x10000000)
+
+/* RCC AHB2 peripheral reset register (RCC_AHB2RSTR) */
+#define  RCC_AHB2RSTR_DCMIRST                ((uint32_t) 0x00000001)
+#define  RCC_AHB2RSTR_CRYPRST                ((uint32_t) 0x00000010)
+#define  RCC_AHB2RSTR_HSAHRST                ((uint32_t) 0x00000020)
+#define  RCC_AHB2RSTR_RNGRST                 ((uint32_t) 0x00000040)
+#define  RCC_AHB2RSTR_OTGFSRST               ((uint32_t) 0x00000080)
+
+/* RCC AHB3 peripheral reset register (RCC_AHB3RSTR) */
+#define  RCC_AHB3RSTR_FSMCRST                ((uint32_t) 0x00000001
+
+/* RCC AHB1 peripheral clock register (RCC_AHB1ENR) */
+#define  RCC_AHB1ENR_GPIOAEN                 ((uint32_t) 0x00000001)
+#define  RCC_AHB1ENR_GPIOBEN                 ((uint32_t) 0x00000002)
+#define  RCC_AHB1ENR_GPIOCEN                 ((uint32_t) 0x00000004)
+#define  RCC_AHB1ENR_GPIODEN                 ((uint32_t) 0x00000008)
+#define  RCC_AHB1ENR_GPIOEEN                 ((uint32_t) 0x00000010)
+#define  RCC_AHB1ENR_GPIOFEN                 ((uint32_t) 0x00000020)
+#define  RCC_AHB1ENR_GPIOGEN                 ((uint32_t) 0x00000040)
+#define  RCC_AHB1ENR_GPIOHEN                 ((uint32_t) 0x00000080)
+#define  RCC_AHB1ENR_GPIOIEN                 ((uint32_t) 0x00000100)
+#define  RCC_AHB1ENR_CRCEN                   ((uint32_t) 0x00001000)
+#define  RCC_AHB1ENR_BKPSRAMEN               ((uint32_t) 0x00040000)
+#define  RCC_AHB1ENR_CCMDATARAMEN            ((uint32_t) 0x00100000)
+#define  RCC_AHB1ENR_DMA1EN                  ((uint32_t) 0x00200000)
+#define  RCC_AHB1ENR_DMA2EN                  ((uint32_t) 0x00400000)
+#define  RCC_AHB1ENR_ETHMACEN                ((uint32_t) 0x02000000)
+#define  RCC_AHB1ENR_ETHMACTXEN              ((uint32_t) 0x04000000)
+#define  RCC_AHB1ENR_ETHMACRXEN              ((uint32_t) 0x08000000)
+#define  RCC_AHB1ENR_ETHMACPTPEN             ((uint32_t) 0x10000000)
+#define  RCC_AHB1ENR_OTGHSEN                 ((uint32_t) 0x20000000)
+#define  RCC_AHB1ENR_OTGHSULPIEN             ((uint32_t) 0x40000000)
+
+/* RCC AHB2 peripheral clock enable register (RCC_AHB2ENR)*/
+#define  RCC_AHB2ENR_DCMIEN                  ((uint32_t) 0x00000001)
+#define  RCC_AHB2ENR_CRYPEN                  ((uint32_t) 0x00000010)
+#define  RCC_AHB2ENR_HASHEN                  ((uint32_t) 0x00000020)
+#define  RCC_AHB2ENR_RNGEN                   ((uint32_t) 0x00000040)
+#define  RCC_AHB2ENR_OTGFSEN                 ((uint32_t) 0x00000080)
+
+/* RCC AHB3 peripheral clock enable register (RCC_AHB3ENR)*/
+#define  RCC_AHB3ENR_FSMCEN                  ((uint32_t) 0x00000001)
+
+/* RCC APB1 peripheral clock enable register (RCC_APB1ENR)*/
+#define  RCC_APB1ENR_TIM2EN                  ((uint32_t) 0x00000001)
+#define  RCC_APB1ENR_TIM3EN                  ((uint32_t) 0x00000002)
+#define  RCC_APB1ENR_TIM4EN                  ((uint32_t) 0x00000004)
+#define  RCC_APB1ENR_TIM5EN                  ((uint32_t) 0x00000008)
+#define  RCC_APB1ENR_TIM6EN                  ((uint32_t) 0x00000010)
+#define  RCC_APB1ENR_TIM7EN                  ((uint32_t) 0x00000020)
+#define  RCC_APB1ENR_TIM12EN                 ((uint32_t) 0x00000040)
+#define  RCC_APB1ENR_TIM13EN                 ((uint32_t) 0x00000080)
+#define  RCC_APB1ENR_TIM14EN                 ((uint32_t) 0x00000100)
+#define  RCC_APB1ENR_WWDGEN                  ((uint32_t) 0x00000800)
+#define  RCC_APB1ENR_SPI2EN                  ((uint32_t) 0x00004000)
+#define  RCC_APB1ENR_SPI3EN                  ((uint32_t) 0x00008000)
+#define  RCC_APB1ENR_USART2EN                ((uint32_t) 0x00020000)
+#define  RCC_APB1ENR_USART3EN                ((uint32_t) 0x00040000)
+#define  RCC_APB1ENR_UART4EN                 ((uint32_t) 0x00080000)
+#define  RCC_APB1ENR_UART5EN                 ((uint32_t) 0x00100000)
+#define  RCC_APB1ENR_I2C1EN                  ((uint32_t) 0x00200000)
+#define  RCC_APB1ENR_I2C2EN                  ((uint32_t) 0x00400000)
+#define  RCC_APB1ENR_I2C3EN                  ((uint32_t) 0x00800000)
+#define  RCC_APB1ENR_CAN1EN                  ((uint32_t) 0x02000000)
+#define  RCC_APB1ENR_CAN2EN                  ((uint32_t) 0x04000000)
+#define  RCC_APB1ENR_PWREN                   ((uint32_t) 0x10000000)
+#define  RCC_APB1ENR_DACEN                   ((uint32_t) 0x20000000)
+
+/* RCC APB2 peripheral clock enable register (RCC_APB2ENR) */
+#define  RCC_APB2ENR_TIM1EN                  ((uint32_t) 0x00000001)
+#define  RCC_APB2ENR_TIM8EN                  ((uint32_t) 0x00000002)
+#define  RCC_APB2ENR_USART1EN                ((uint32_t) 0x00000010)
+#define  RCC_APB2ENR_USART6EN                ((uint32_t) 0x00000020)
+#define  RCC_APB2ENR_ADC1EN                  ((uint32_t) 0x00000100)
+#define  RCC_APB2ENR_ADC2EN                  ((uint32_t) 0x00000200)
+#define  RCC_APB2ENR_ADC3EN                  ((uint32_t) 0x00000400)
+#define  RCC_APB2ENR_SDIOEN                  ((uint32_t) 0x00000800)
+#define  RCC_APB2ENR_SPI1EN                  ((uint32_t) 0x00001000)
+#define  RCC_APB2ENR_SYSCFGEN                ((uint32_t) 0x00004000)
+#define  RCC_APB2ENR_TIM11EN                 ((uint32_t) 0x00040000)
+#define  RCC_APB2ENR_TIM10EN                 ((uint32_t) 0x00020000)
+#define  RCC_APB2ENR_TIM9EN                  ((uint32_t) 0x00010000)
+
+/* RCC AHB1 peripheral clock enable in low power mode register (RCC_AHB1LPENR) */
+#define  RCC_AHB1LPENR_GPIOALPEN             ((uint32_t) 0x00000001)
+#define  RCC_AHB1LPENR_GPIOBLPEN             ((uint32_t) 0x00000002)
+#define  RCC_AHB1LPENR_GPIOCLPEN             ((uint32_t) 0x00000004)
+#define  RCC_AHB1LPENR_GPIODLPEN             ((uint32_t) 0x00000008)
+#define  RCC_AHB1LPENR_GPIOELPEN             ((uint32_t) 0x00000010)
+#define  RCC_AHB1LPENR_GPIOFLPEN             ((uint32_t) 0x00000020)
+#define  RCC_AHB1LPENR_GPIOGLPEN             ((uint32_t) 0x00000040)
+#define  RCC_AHB1LPENR_GPIOHLPEN             ((uint32_t) 0x00000080)
+#define  RCC_AHB1LPENR_GPIOILPEN             ((uint32_t) 0x00000100)
+#define  RCC_AHB1LPENR_CRCLPEN               ((uint32_t) 0x00001000)
+#define  RCC_AHB1LPENR_FLITFLPEN             ((uint32_t) 0x00008000)
+#define  RCC_AHB1LPENR_SRAM1LPEN             ((uint32_t) 0x00010000)
+#define  RCC_AHB1LPENR_SRAM2LPEN             ((uint32_t) 0x00020000)
+#define  RCC_AHB1LPENR_BKPSRAMLPEN           ((uint32_t) 0x00040000)
+#define  RCC_AHB1LPENR_DMA1LPEN              ((uint32_t) 0x00200000)
+#define  RCC_AHB1LPENR_DMA2LPEN              ((uint32_t) 0x00400000)
+#define  RCC_AHB1LPENR_ETHMACLPEN            ((uint32_t) 0x02000000)
+#define  RCC_AHB1LPENR_ETHMACTXLPEN          ((uint32_t) 0x04000000)
+#define  RCC_AHB1LPENR_ETHMACRXLPEN          ((uint32_t) 0x08000000)
+#define  RCC_AHB1LPENR_ETHMACPTPLPEN         ((uint32_t) 0x10000000)
+#define  RCC_AHB1LPENR_OTGHSLPEN             ((uint32_t) 0x20000000)
+#define  RCC_AHB1LPENR_OTGHSULPILPEN         ((uint32_t) 0x40000000)
+
+/* RCC AHB2 peripheral clock enable in low power mode register (RCC_AHB2LPENR) */
+#define  RCC_AHB2LPENR_DCMILPEN              ((uint32_t) 0x00000001)
+#define  RCC_AHB2LPENR_CRYPLPEN              ((uint32_t) 0x00000010)
+#define  RCC_AHB2LPENR_HASHLPEN              ((uint32_t) 0x00000020)
+#define  RCC_AHB2LPENR_RNGLPEN               ((uint32_t) 0x00000040)
+#define  RCC_AHB2LPENR_OTGFSLPEN             ((uint32_t) 0x00000080)
+
+/* RCC AHB3 peripheral clock enable in low power mode register (RCC_AHB3LPENR) */
+#define  RCC_AHB3LPENR_FSMCLPEN              ((uint32_t) 0x00000001)
+
+/* RCC APB1 peripheral clock enable in low power mode register (RCC_APB1LPENR) */
+#define  RCC_APB1LPENR_TIM2LPEN              ((uint32_t) 0x00000001)
+#define  RCC_APB1LPENR_TIM3LPEN              ((uint32_t) 0x00000002)
+#define  RCC_APB1LPENR_TIM4LPEN              ((uint32_t) 0x00000004)
+#define  RCC_APB1LPENR_TIM5LPEN              ((uint32_t) 0x00000008)
+#define  RCC_APB1LPENR_TIM6LPEN              ((uint32_t) 0x00000010)
+#define  RCC_APB1LPENR_TIM7LPEN              ((uint32_t) 0x00000020)
+#define  RCC_APB1LPENR_TIM12LPEN             ((uint32_t) 0x00000040)
+#define  RCC_APB1LPENR_TIM13LPEN             ((uint32_t) 0x00000080)
+#define  RCC_APB1LPENR_TIM14LPEN             ((uint32_t) 0x00000100)
+#define  RCC_APB1LPENR_WWDGLPEN              ((uint32_t) 0x00000800)
+#define  RCC_APB1LPENR_SPI2LPEN              ((uint32_t) 0x00004000)
+#define  RCC_APB1LPENR_SPI3LPEN              ((uint32_t) 0x00008000)
+#define  RCC_APB1LPENR_USART2LPEN            ((uint32_t) 0x00020000)
+#define  RCC_APB1LPENR_USART3LPEN            ((uint32_t) 0x00040000)
+#define  RCC_APB1LPENR_UART4LPEN             ((uint32_t) 0x00080000)
+#define  RCC_APB1LPENR_UART5LPEN             ((uint32_t) 0x00100000)
+#define  RCC_APB1LPENR_I2C1LPEN              ((uint32_t) 0x00200000)
+#define  RCC_APB1LPENR_I2C2LPEN              ((uint32_t) 0x00400000)
+#define  RCC_APB1LPENR_I2C3LPEN              ((uint32_t) 0x00800000)
+#define  RCC_APB1LPENR_CAN1LPEN              ((uint32_t) 0x02000000)
+#define  RCC_APB1LPENR_CAN2LPEN              ((uint32_t) 0x04000000)
+#define  RCC_APB1LPENR_PWRLPEN               ((uint32_t) 0x10000000)
+#define  RCC_APB1LPENR_DACLPEN               ((uint32_t) 0x20000000)
+
+/* RCC APB2 peripheral clock enabled in low power mode register (RCC_APB2LPENR) */
+#define  RCC_APB2LPENR_TIM1LPEN              ((uint32_t) 0x00000001)
+#define  RCC_APB2LPENR_TIM8LPEN              ((uint32_t) 0x00000002)
+#define  RCC_APB2LPENR_USART1LPEN            ((uint32_t) 0x00000010)
+#define  RCC_APB2LPENR_USART6LPEN            ((uint32_t) 0x00000020)
+#define  RCC_APB2LPENR_ADC1LPEN              ((uint32_t) 0x00000100)
+#define  RCC_APB2LPENR_ADC2PEN               ((uint32_t) 0x00000200)
+#define  RCC_APB2LPENR_ADC3LPEN              ((uint32_t) 0x00000400)
+#define  RCC_APB2LPENR_SDIOLPEN              ((uint32_t) 0x00000800)
+#define  RCC_APB2LPENR_SPI1LPEN              ((uint32_t) 0x00001000)
+#define  RCC_APB2LPENR_SYSCFGLPEN            ((uint32_t) 0x00004000)
+#define  RCC_APB2LPENR_TIM9LPEN              ((uint32_t) 0x00010000)
+#define  RCC_APB2LPENR_TIM10LPEN             ((uint32_t) 0x00020000)
+#define  RCC_APB2LPENR_TIM11LPEN             ((uint32_t) 0x00040000)
+
+/* RCC APB2 peripheral reset register (RCC_APB2RSTR) */
+#define  RCC_APB2RSTR_TIM1RST                ((uint32_t)0x00000001)
+#define  RCC_APB2RSTR_TIM8RST                ((uint32_t)0x00000002)
+#define  RCC_APB2RSTR_USART1RST              ((uint32_t)0x00000010)
+#define  RCC_APB2RSTR_USART6RST              ((uint32_t)0x00000020)
+#define  RCC_APB2RSTR_ADCRST                 ((uint32_t)0x00000100)
+#define  RCC_APB2RSTR_SDIORST                ((uint32_t)0x00000800)
+#define  RCC_APB2RSTR_SPI1RST                ((uint32_t)0x00001000)
+#define  RCC_APB2RSTR_SYSCFGRST              ((uint32_t)0x00004000)
+#define  RCC_APB2RSTR_TIM9RST                ((uint32_t)0x00010000)
+#define  RCC_APB2RSTR_TIM10RST               ((uint32_t)0x00020000)
+#define  RCC_APB2RSTR_TIM11RST               ((uint32_t)0x00040000)
+
+/* RCC Backup domain control register (RCC_BDCR) */
+#define  RCC_BDCR_LSEON                      ((uint32_t) 0x00000001)
+#define  RCC_BDCR_LSERDY                     ((uint32_t) 0x00000002)
+#define  RCC_BDCR_LSEBYP                     ((uint32_t) 0x00000004)
+
+#define  RCC_BDCR_RTCSEL                    ((uint32_t) 0x00000300)
+#define  RCC_BDCR_RTCSEL_0                  ((uint32_t) 0x00000100)
+#define  RCC_BDCR_RTCSEL_1                  ((uint32_t) 0x00000200)
+
+#define  RCC_BDCR_RTCEN                      ((uint32_t) 0x00008000)
+#define  RCC_BDCR_BDRST                      ((uint32_t) 0x00010000)
+
+/* RCC clock control & status register */
+#define  RCC_CSR_LSION                       ((uint32_t) 0x00000001)
+#define  RCC_CSR_LSIRDY                      ((uint32_t) 0x00000002)
+#define  RCC_CSR_RMVF                        ((uint32_t) 0x01000000)
+#define  RCC_CSR_BORRSTF                     ((uint32_t) 0x02000000)
+#define  RCC_CSR_PADRSTF                     ((uint32_t) 0x04000000)
+#define  RCC_CSR_PORRSTF                     ((uint32_t) 0x08000000)
+#define  RCC_CSR_SFTRSTF                     ((uint32_t) 0x10000000)
+#define  RCC_CSR_WDGRSTF                     ((uint32_t) 0x20000000)
+#define  RCC_CSR_WWDGRSTF                    ((uint32_t) 0x40000000)
+#define  RCC_CSR_LPWRRSTF                    ((uint32_t) 0x80000000)
+
+/* RCC spread spectrum clock generation register (RCC_SSCGR) */
+#define  RCC_SSCGR_MODPER                    ((uint32_t) 0x00001FFF)
+#define  RCC_SSCGR_INCSTEP                   ((uint32_t) 0x0FFFE000)
+#define  RCC_SSCGR_SPREADSEL                 ((uint32_t) 0x40000000)
+#define  RCC_SSCGR_SSCGEN                    ((uint32_t) 0x80000000)
+
+/* RCC PLLI2S configuration register (RCC_PLLI2SCFGR) */
+#define  RCC_PLLI2SCFGR_PLLI2SN              ((uint32_t) 0x00007FC0)
+#define  RCC_PLLI2SCFGR_PLLI2SR              ((uint32_t) 0x70000000)
+
+/* Exported Constants */
+#define RCC_HSE_OFF                      ((uint8_t) 0x00)
+#define RCC_HSE_ON                       ((uint8_t) 0x01)
+#define RCC_HSE_Bypass                   ((uint8_t) 0x05)
+#define IS_RCC_HSE(HSE) (((HSE) == RCC_HSE_OFF) || ((HSE) == RCC_HSE_ON) || \
+                     ((HSE) == RCC_HSE_Bypass))
+
+/* RCC_PLL_Clock_Source */
+#define RCC_PLLSource_HSI                ((uint32_t) 0x00000000)
+#define RCC_PLLSource_HSE                ((uint32_t) 0x00400000)
+#define IS_RCC_PLL_SOURCE(SOURCE) (((SOURCE) == RCC_PLLSource_HSI) || \
+                               ((SOURCE) == RCC_PLLSource_HSE))
+#define IS_RCC_PLLM_VALUE(VALUE) ((VALUE) <= 63)
+#define IS_RCC_PLLN_VALUE(VALUE) ((192 <= (VALUE)) && ((VALUE) <= 432))
+#define IS_RCC_PLLP_VALUE(VALUE) (((VALUE) == 2) || ((VALUE) == 4) || ((VALUE) == 6) || ((VALUE) == 8))
+#define IS_RCC_PLLQ_VALUE(VALUE) ((4 <= (VALUE)) && ((VALUE) <= 15))
+
+#define IS_RCC_PLLI2SN_VALUE(VALUE) ((192 <= (VALUE)) && ((VALUE) <= 432))
+#define IS_RCC_PLLI2SR_VALUE(VALUE) ((2 <= (VALUE)) && ((VALUE) <= 7))
+
+/* RCC_System_Clock_Source */
+#define RCC_SYSCLKSource_HSI             ((uint32_t) 0x00000000)
+#define RCC_SYSCLKSource_HSE             ((uint32_t) 0x00000001)
+#define RCC_SYSCLKSource_PLLCLK          ((uint32_t) 0x00000002)
+#define IS_RCC_SYSCLK_SOURCE(SOURCE) (((SOURCE) == RCC_SYSCLKSource_HSI) || \
+                                  ((SOURCE) == RCC_SYSCLKSource_HSE) || \
+                                  ((SOURCE) == RCC_SYSCLKSource_PLLCLK))
+
+/* RCC_AHB_Clock_Source */
+#define RCC_SYSCLK_Div1                  ((uint32_t) 0x00000000)
+#define RCC_SYSCLK_Div2                  ((uint32_t) 0x00000080)
+#define RCC_SYSCLK_Div4                  ((uint32_t) 0x00000090)
+#define RCC_SYSCLK_Div8                  ((uint32_t) 0x000000A0)
+#define RCC_SYSCLK_Div16                 ((uint32_t) 0x000000B0)
+#define RCC_SYSCLK_Div64                 ((uint32_t) 0x000000C0)
+#define RCC_SYSCLK_Div128                ((uint32_t) 0x000000D0)
+#define RCC_SYSCLK_Div256                ((uint32_t) 0x000000E0)
+#define RCC_SYSCLK_Div512                ((uint32_t) 0x000000F0)
+#define IS_RCC_HCLK(HCLK) (((HCLK) == RCC_SYSCLK_Div1) || ((HCLK) == RCC_SYSCLK_Div2) || \
+                       ((HCLK) == RCC_SYSCLK_Div4) || ((HCLK) == RCC_SYSCLK_Div8) || \
+                       ((HCLK) == RCC_SYSCLK_Div16) || ((HCLK) == RCC_SYSCLK_Div64) || \
+                       ((HCLK) == RCC_SYSCLK_Div128) || ((HCLK) == RCC_SYSCLK_Div256) || \
+                       ((HCLK) == RCC_SYSCLK_Div512))
+
+/* RCC_APB1_APB2_Clock_Source */
+#define RCC_HCLK_Div1                    ((uint32_t) 0x00000000)
+#define RCC_HCLK_Div2                    ((uint32_t) 0x00001000)
+#define RCC_HCLK_Div4                    ((uint32_t) 0x00001400)
+#define RCC_HCLK_Div8                    ((uint32_t) 0x00001800)
+#define RCC_HCLK_Div16                   ((uint32_t) 0x00001C00)
+#define IS_RCC_PCLK(PCLK) (((PCLK) == RCC_HCLK_Div1) || ((PCLK) == RCC_HCLK_Div2) || \
+                       ((PCLK) == RCC_HCLK_Div4) || ((PCLK) == RCC_HCLK_Div8) || \
+                       ((PCLK) == RCC_HCLK_Div16))
+
+/* RCC_Interrupt_Source */
+#define RCC_IT_LSIRDY                    ((uint8_t) 0x01)
+#define RCC_IT_LSERDY                    ((uint8_t) 0x02)
+#define RCC_IT_HSIRDY                    ((uint8_t) 0x04)
+#define RCC_IT_HSERDY                    ((uint8_t) 0x08)
+#define RCC_IT_PLLRDY                    ((uint8_t) 0x10)
+#define RCC_IT_PLLI2SRDY                 ((uint8_t) 0x20)
+#define RCC_IT_CSS                       ((uint8_t) 0x80)
+#define IS_RCC_IT(IT) ((((IT) & (uint8_t) 0xC0) == 0x00) && ((IT) != 0x00))
+#define IS_RCC_GET_IT(IT) (((IT) == RCC_IT_LSIRDY) || ((IT) == RCC_IT_LSERDY) || \
+                       ((IT) == RCC_IT_HSIRDY) || ((IT) == RCC_IT_HSERDY) || \
+                       ((IT) == RCC_IT_PLLRDY) || ((IT) == RCC_IT_CSS) || \
+                       ((IT) == RCC_IT_PLLI2SRDY))
+#define IS_RCC_CLEAR_IT(IT) ((((IT) & (uint8_t) 0x40) == 0x00) && ((IT) != 0x00))
+
+/* RCC_LSE_Configuration */
+#define RCC_LSE_OFF                      ((uint8_t) 0x00)
+#define RCC_LSE_ON                       ((uint8_t) 0x01)
+#define RCC_LSE_Bypass                   ((uint8_t) 0x04)
+#define IS_RCC_LSE(LSE) (((LSE) == RCC_LSE_OFF) || ((LSE) == RCC_LSE_ON) || \
+                     ((LSE) == RCC_LSE_Bypass))
+
+/* RCC_RTC_Clock_Source */
+#define RCC_RTCCLKSource_LSE             ((uint32_t) 0x00000100)
+#define RCC_RTCCLKSource_LSI             ((uint32_t) 0x00000200)
+#define RCC_RTCCLKSource_HSE_Div2        ((uint32_t) 0x00020300)
+#define RCC_RTCCLKSource_HSE_Div3        ((uint32_t) 0x00030300)
+#define RCC_RTCCLKSource_HSE_Div4        ((uint32_t) 0x00040300)
+#define RCC_RTCCLKSource_HSE_Div5        ((uint32_t) 0x00050300)
+#define RCC_RTCCLKSource_HSE_Div6        ((uint32_t) 0x00060300)
+#define RCC_RTCCLKSource_HSE_Div7        ((uint32_t) 0x00070300)
+#define RCC_RTCCLKSource_HSE_Div8        ((uint32_t) 0x00080300)
+#define RCC_RTCCLKSource_HSE_Div9        ((uint32_t) 0x00090300)
+#define RCC_RTCCLKSource_HSE_Div10       ((uint32_t) 0x000A0300)
+#define RCC_RTCCLKSource_HSE_Div11       ((uint32_t) 0x000B0300)
+#define RCC_RTCCLKSource_HSE_Div12       ((uint32_t) 0x000C0300)
+#define RCC_RTCCLKSource_HSE_Div13       ((uint32_t) 0x000D0300)
+#define RCC_RTCCLKSource_HSE_Div14       ((uint32_t) 0x000E0300)
+#define RCC_RTCCLKSource_HSE_Div15       ((uint32_t) 0x000F0300)
+#define RCC_RTCCLKSource_HSE_Div16       ((uint32_t) 0x00100300)
+#define RCC_RTCCLKSource_HSE_Div17       ((uint32_t) 0x00110300)
+#define RCC_RTCCLKSource_HSE_Div18       ((uint32_t) 0x00120300)
+#define RCC_RTCCLKSource_HSE_Div19       ((uint32_t) 0x00130300)
+#define RCC_RTCCLKSource_HSE_Div20       ((uint32_t) 0x00140300)
+#define RCC_RTCCLKSource_HSE_Div21       ((uint32_t) 0x00150300)
+#define RCC_RTCCLKSource_HSE_Div22       ((uint32_t) 0x00160300)
+#define RCC_RTCCLKSource_HSE_Div23       ((uint32_t) 0x00170300)
+#define RCC_RTCCLKSource_HSE_Div24       ((uint32_t) 0x00180300)
+#define RCC_RTCCLKSource_HSE_Div25       ((uint32_t) 0x00190300)
+#define RCC_RTCCLKSource_HSE_Div26       ((uint32_t) 0x001A0300)
+#define RCC_RTCCLKSource_HSE_Div27       ((uint32_t) 0x001B0300)
+#define RCC_RTCCLKSource_HSE_Div28       ((uint32_t) 0x001C0300)
+#define RCC_RTCCLKSource_HSE_Div29       ((uint32_t) 0x001D0300)
+#define RCC_RTCCLKSource_HSE_Div30       ((uint32_t) 0x001E0300)
+#define RCC_RTCCLKSource_HSE_Div31       ((uint32_t) 0x001F0300)
+#define IS_RCC_RTCCLK_SOURCE(SOURCE) (((SOURCE) == RCC_RTCCLKSource_LSE) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_LSI) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div2) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div3) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div4) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div5) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div6) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div7) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div8) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div9) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div10) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div11) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div12) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div13) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div14) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div15) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div16) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div17) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div18) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div19) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div20) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div21) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div22) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div23) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div24) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div25) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div26) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div27) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div28) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div29) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div30) || \
+                                      ((SOURCE) == RCC_RTCCLKSource_HSE_Div31))
+/* RCC_I2S_Clock_Source */
+#define RCC_I2S2CLKSource_PLLI2S             ((uint8_t) 0x00)
+#define RCC_I2S2CLKSource_Ext                ((uint8_t) 0x01)
+#define IS_RCC_I2SCLK_SOURCE(SOURCE) (((SOURCE) == RCC_I2S2CLKSource_PLLI2S) || ((SOURCE) == RCC_I2S2CLKSource_Ext))
+
+/* RCC_AHB1_Peripherals */
+#define RCC_AHB1Periph_GPIOA             ((uint32_t) 0x00000001)
+#define RCC_AHB1Periph_GPIOB             ((uint32_t) 0x00000002)
+#define RCC_AHB1Periph_GPIOC             ((uint32_t) 0x00000004)
+#define RCC_AHB1Periph_GPIOD             ((uint32_t) 0x00000008)
+#define RCC_AHB1Periph_GPIOE             ((uint32_t) 0x00000010)
+#define RCC_AHB1Periph_GPIOF             ((uint32_t) 0x00000020)
+#define RCC_AHB1Periph_GPIOG             ((uint32_t) 0x00000040)
+#define RCC_AHB1Periph_GPIOH             ((uint32_t) 0x00000080)
+#define RCC_AHB1Periph_GPIOI             ((uint32_t) 0x00000100)
+#define RCC_AHB1Periph_CRC               ((uint32_t) 0x00001000)
+#define RCC_AHB1Periph_FLITF             ((uint32_t) 0x00008000)
+#define RCC_AHB1Periph_SRAM1             ((uint32_t) 0x00010000)
+#define RCC_AHB1Periph_SRAM2             ((uint32_t) 0x00020000)
+#define RCC_AHB1Periph_BKPSRAM           ((uint32_t) 0x00040000)
+#define RCC_AHB1Periph_CCMDATARAMEN      ((uint32_t) 0x00100000)
+#define RCC_AHB1Periph_DMA1              ((uint32_t) 0x00200000)
+#define RCC_AHB1Periph_DMA2              ((uint32_t) 0x00400000)
+#define RCC_AHB1Periph_ETH_MAC           ((uint32_t) 0x02000000)
+#define RCC_AHB1Periph_ETH_MAC_Tx        ((uint32_t) 0x04000000)
+#define RCC_AHB1Periph_ETH_MAC_Rx        ((uint32_t) 0x08000000)
+#define RCC_AHB1Periph_ETH_MAC_PTP       ((uint32_t) 0x10000000)
+#define RCC_AHB1Periph_OTG_HS            ((uint32_t) 0x20000000)
+#define RCC_AHB1Periph_OTG_HS_ULPI       ((uint32_t) 0x40000000)
+#define IS_RCC_AHB1_CLOCK_PERIPH(PERIPH) ((((PERIPH) & 0x818BEE00) == 0x00) && ((PERIPH) != 0x00))
+#define IS_RCC_AHB1_RESET_PERIPH(PERIPH) ((((PERIPH) & 0xDD9FEE00) == 0x00) && ((PERIPH) != 0x00))
+#define IS_RCC_AHB1_LPMODE_PERIPH(PERIPH) ((((PERIPH) & 0x81986E00) == 0x00) && ((PERIPH) != 0x00))
+
+/* RCC_AHB2_Peripherals */
+#define RCC_AHB2Periph_DCMI              ((uint32_t) 0x00000001)
+#define RCC_AHB2Periph_CRYP              ((uint32_t) 0x00000010)
+#define RCC_AHB2Periph_HASH              ((uint32_t) 0x00000020)
+#define RCC_AHB2Periph_RNG               ((uint32_t) 0x00000040)
+#define RCC_AHB2Periph_OTG_FS            ((uint32_t) 0x00000080)
+#define IS_RCC_AHB2_PERIPH(PERIPH) ((((PERIPH) & 0xFFFFFF0E) == 0x00) && ((PERIPH) != 0x00))
+
+/* RCC_AHB3_Peripherals */
+#define RCC_AHB3Periph_FSMC               ((uint32_t) 0x00000001)
+#define IS_RCC_AHB3_PERIPH(PERIPH) ((((PERIPH) & 0xFFFFFFFE) == 0x00) && ((PERIPH) != 0x00))
+
+/* RCC_APB1_Peripherals */
+#define RCC_APB1Periph_TIM2              ((uint32_t) 0x00000001)
+#define RCC_APB1Periph_TIM3              ((uint32_t) 0x00000002)
+#define RCC_APB1Periph_TIM4              ((uint32_t) 0x00000004)
+#define RCC_APB1Periph_TIM5              ((uint32_t) 0x00000008)
+#define RCC_APB1Periph_TIM6              ((uint32_t) 0x00000010)
+#define RCC_APB1Periph_TIM7              ((uint32_t) 0x00000020)
+#define RCC_APB1Periph_TIM12             ((uint32_t) 0x00000040)
+#define RCC_APB1Periph_TIM13             ((uint32_t) 0x00000080)
+#define RCC_APB1Periph_TIM14             ((uint32_t) 0x00000100)
+#define RCC_APB1Periph_WWDG              ((uint32_t) 0x00000800)
+#define RCC_APB1Periph_SPI2              ((uint32_t) 0x00004000)
+#define RCC_APB1Periph_SPI3              ((uint32_t) 0x00008000)
+#define RCC_APB1Periph_USART2            ((uint32_t) 0x00020000)
+#define RCC_APB1Periph_USART3            ((uint32_t) 0x00040000)
+#define RCC_APB1Periph_UART4             ((uint32_t) 0x00080000)
+#define RCC_APB1Periph_UART5             ((uint32_t) 0x00100000)
+#define RCC_APB1Periph_I2C1              ((uint32_t) 0x00200000)
+#define RCC_APB1Periph_I2C2              ((uint32_t) 0x00400000)
+#define RCC_APB1Periph_I2C3              ((uint32_t) 0x00800000)
+#define RCC_APB1Periph_CAN1              ((uint32_t) 0x02000000)
+#define RCC_APB1Periph_CAN2              ((uint32_t) 0x04000000)
+#define RCC_APB1Periph_PWR               ((uint32_t) 0x10000000)
+#define RCC_APB1Periph_DAC               ((uint32_t) 0x20000000)
+#define IS_RCC_APB1_PERIPH(PERIPH) ((((PERIPH) & 0xC9013600) == 0x00) && ((PERIPH) != 0x00))
+
+/* RCC_APB2_Peripherals */
+#define RCC_APB2Periph_TIM1              ((uint32_t) 0x00000001)
+#define RCC_APB2Periph_TIM8              ((uint32_t) 0x00000002)
+#define RCC_APB2Periph_USART1            ((uint32_t) 0x00000010)
+#define RCC_APB2Periph_USART6            ((uint32_t) 0x00000020)
+#define RCC_APB2Periph_ADC               ((uint32_t) 0x00000100)
+#define RCC_APB2Periph_ADC1              ((uint32_t) 0x00000100)
+#define RCC_APB2Periph_ADC2              ((uint32_t) 0x00000200)
+#define RCC_APB2Periph_ADC3              ((uint32_t) 0x00000400)
+#define RCC_APB2Periph_SDIO              ((uint32_t) 0x00000800)
+#define RCC_APB2Periph_SPI1              ((uint32_t) 0x00001000)
+#define RCC_APB2Periph_SYSCFG            ((uint32_t) 0x00004000)
+#define RCC_APB2Periph_TIM9              ((uint32_t) 0x00010000)
+#define RCC_APB2Periph_TIM10             ((uint32_t) 0x00020000)
+#define RCC_APB2Periph_TIM11             ((uint32_t) 0x00040000)
+#define IS_RCC_APB2_PERIPH(PERIPH) ((((PERIPH) & 0xFFF8A0CC) == 0x00) && ((PERIPH) != 0x00))
+#define IS_RCC_APB2_RESET_PERIPH(PERIPH) ((((PERIPH) & 0xFFF8A6CC) == 0x00) && ((PERIPH) != 0x00))
+
+/* RCC_MCO1_Clock_Source_Prescaler */
+#define RCC_MCO1Source_HSI               ((uint32_t) 0x00000000)
+#define RCC_MCO1Source_LSE               ((uint32_t) 0x00200000)
+#define RCC_MCO1Source_HSE               ((uint32_t) 0x00400000)
+#define RCC_MCO1Source_PLLCLK            ((uint32_t) 0x00600000)
+#define RCC_MCO1Div_1                    ((uint32_t) 0x00000000)
+#define RCC_MCO1Div_2                    ((uint32_t) 0x04000000)
+#define RCC_MCO1Div_3                    ((uint32_t) 0x05000000)
+#define RCC_MCO1Div_4                    ((uint32_t) 0x06000000)
+#define RCC_MCO1Div_5                    ((uint32_t) 0x07000000)
+#define IS_RCC_MCO1SOURCE(SOURCE) (((SOURCE) == RCC_MCO1Source_HSI) || ((SOURCE) == RCC_MCO1Source_LSE) || \
+                               ((SOURCE) == RCC_MCO1Source_HSE) || ((SOURCE) == RCC_MCO1Source_PLLCLK))
+
+#define IS_RCC_MCO1DIV(DIV) (((DIV) == RCC_MCO1Div_1) || ((DIV) == RCC_MCO1Div_2) || \
+                         ((DIV) == RCC_MCO1Div_3) || ((DIV) == RCC_MCO1Div_4) || \
+                         ((DIV) == RCC_MCO1Div_5))
+
+/* RCC_MCO2_Clock_Source_Prescaler */
+#define RCC_MCO2Source_SYSCLK            ((uint32_t) 0x00000000)
+#define RCC_MCO2Source_PLLI2SCLK         ((uint32_t) 0x40000000)
+#define RCC_MCO2Source_HSE               ((uint32_t) 0x80000000)
+#define RCC_MCO2Source_PLLCLK            ((uint32_t) 0xC0000000)
+#define RCC_MCO2Div_1                    ((uint32_t) 0x00000000)
+#define RCC_MCO2Div_2                    ((uint32_t) 0x20000000)
+#define RCC_MCO2Div_3                    ((uint32_t) 0x28000000)
+#define RCC_MCO2Div_4                    ((uint32_t) 0x30000000)
+#define RCC_MCO2Div_5                    ((uint32_t) 0x38000000)
+#define IS_RCC_MCO2SOURCE(SOURCE) (((SOURCE) == RCC_MCO2Source_SYSCLK) || ((SOURCE) == RCC_MCO2Source_PLLI2SCLK)|| \
+                               ((SOURCE) == RCC_MCO2Source_HSE) || ((SOURCE) == RCC_MCO2Source_PLLCLK))
+
+#define IS_RCC_MCO2DIV(DIV) (((DIV) == RCC_MCO2Div_1) || ((DIV) == RCC_MCO2Div_2) || \
+                         ((DIV) == RCC_MCO2Div_3) || ((DIV) == RCC_MCO2Div_4) || \
+                         ((DIV) == RCC_MCO2Div_5))
+
+/* RCC_Flag */
+#define RCC_FLAG_HSIRDY                  ((uint8_t) 0x21)
+#define RCC_FLAG_HSERDY                  ((uint8_t) 0x31)
+#define RCC_FLAG_PLLRDY                  ((uint8_t) 0x39)
+#define RCC_FLAG_PLLI2SRDY               ((uint8_t) 0x3B)
+#define RCC_FLAG_LSERDY                  ((uint8_t) 0x41)
+#define RCC_FLAG_LSIRDY                  ((uint8_t) 0x61)
+#define RCC_FLAG_BORRST                  ((uint8_t) 0x79)
+#define RCC_FLAG_PINRST                  ((uint8_t) 0x7A)
+#define RCC_FLAG_PORRST                  ((uint8_t) 0x7B)
+#define RCC_FLAG_SFTRST                  ((uint8_t) 0x7C)
+#define RCC_FLAG_IWDGRST                 ((uint8_t) 0x7D)
+#define RCC_FLAG_WWDGRST                 ((uint8_t) 0x7E)
+#define RCC_FLAG_LPWRRST                 ((uint8_t) 0x7F)
+#define IS_RCC_FLAG(FLAG) (((FLAG) == RCC_FLAG_HSIRDY) || ((FLAG) == RCC_FLAG_HSERDY) || \
+                       ((FLAG) == RCC_FLAG_PLLRDY) || ((FLAG) == RCC_FLAG_LSERDY) || \
+                       ((FLAG) == RCC_FLAG_LSIRDY) || ((FLAG) == RCC_FLAG_BORRST) || \
+                       ((FLAG) == RCC_FLAG_PINRST) || ((FLAG) == RCC_FLAG_PORRST) || \
+                       ((FLAG) == RCC_FLAG_SFTRST) || ((FLAG) == RCC_FLAG_IWDGRST)|| \
+                       ((FLAG) == RCC_FLAG_WWDGRST)|| ((FLAG) == RCC_FLAG_LPWRRST)|| \
+                       ((FLAG) == RCC_FLAG_PLLI2SRDY))
+#define IS_RCC_CALIBRATION_VALUE(VALUE) ((VALUE) <= 0x1F)
+
+/**
+ * \brief Reset the RCC clock configuration
+ */
+void soc_rcc_reset(void);
+
+/*
+ * \brief Configures the System clock source, PLL Multiplier and Divider factors,
+ * AHB/APBx prescalers and Flash settings
+ *
+ *
+ * This function should be called only once the RCC clock configuration
+ * is reset to the default reset state (done in SystemInit() function).
+ *
+ */
+void soc_rcc_setsysclock(bool enable_hse, bool enable_pll);
+
+#endif /*!SOC_RCC_H */

--- a/src/arch/socs/stm32f439/soc-rcc.h
+++ b/src/arch/socs/stm32f439/soc-rcc.h
@@ -1,24 +1,35 @@
-/* \file soc-rcc.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef SOC_RCC_H
 #define SOC_RCC_H

--- a/src/arch/socs/stm32f439/soc-scb.h
+++ b/src/arch/socs/stm32f439/soc-scb.h
@@ -1,0 +1,426 @@
+/* \file soc-scb.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef SOC_SCB_H
+#define SOC_SCB_H
+
+#include "regutils.h"
+#include "soc-core.h"
+
+/* System control block design hints and tips
+ * Ensure software uses aligned accesses of the correct size to access the system control block registers:
+ * • except for the CFSR and SHPR1-SHPR3, it must use aligned word accesses
+ * • for the CFSR and SHPR1-SHPR3 it can use byte or aligned halfword or word accesses.
+ *
+ * The processor does not support unaligned accesses to system control block registers
+ *
+ * In a fault handler.
+ *
+ * to determine the true faulting address:
+ *  1. Read and save the MMFAR or BFAR value.
+ *  2. Read the MMARVALID bit in the MMFSR, or the BFARVALID bit in the BFSR.
+ *
+ *  The MMFAR or BFAR address is valid only if this bit is 1.
+ *  Software must follow this sequence because another higher priority exception might change
+ *  the MMFAR or BFAR value. For example, if a higher priority handler preempts the current
+ *  fault handler, the other fault might change the MMFAR or BFAR value.
+ */
+
+/* SCB Registers */
+#define r_CORTEX_M_SCB_ACTLR                REG_ADDR(SCS_BASE + (uint32_t) 0x08)    /* (R/W)  Auxiliary control register */
+
+#define r_CORTEX_M_SCB				        REG_ADDR(SCB_BASE + (uint32_t) 0x00)
+#define r_CORTEX_M_SCB_CPUID                REG_ADDR(SCB_BASE + (uint32_t) 0x00)    /* (R/ )  CPUID Base Register */
+#define r_CORTEX_M_SCB_ICSR                 REG_ADDR(SCB_BASE + (uint32_t) 0x04)    /* (R/W)  Interrupt Control and State Register */
+#define r_CORTEX_M_SCB_VTOR                 REG_ADDR(SCB_BASE + (uint32_t) 0x08)    /* (R/W)  Vector Table Offset Register */
+#define r_CORTEX_M_SCB_AIRCR                REG_ADDR(SCB_BASE + (uint32_t) 0x0C)    /* (R/W)  Application Interrupt and Reset Control Register */
+#define r_CORTEX_M_SCB_SCR                  REG_ADDR(SCB_BASE + (uint32_t) 0x10)    /* (R/W)  System Control Register */
+#define r_CORTEX_M_SCB_CCR                  REG_ADDR(SCB_BASE + (uint32_t) 0x14)    /* (R/W)  Configuration Control Register */
+
+#define r_CORTEX_M_SCB_SHPR1                REG_ADDR(SCB_BASE + (uint32_t) 0x18)    /* (R/W)  System Handlers Priority Registers (4-6) */
+#define r_CORTEX_M_SCB_SHPR2                REG_ADDR(SCB_BASE + (uint32_t) 0x1C)    /* (R/W)  System Handlers Priority Registers (11) */
+#define r_CORTEX_M_SCB_SHPR3                REG_ADDR(SCB_BASE + (uint32_t) 0x20)    /* (R/W)  System Handlers Priority Registers (14-15) */
+
+#define r_CORTEX_M_SCB_SHCSR                REG_ADDR(SCB_BASE + (uint32_t) 0x24)    /* (R/W)  System Handler Control and State Register */
+
+#define r_CORTEX_M_SCB_CFSR                 REG_ADDR(SCB_BASE + (uint32_t) 0x28)    /* (R/W)  Configurable Fault Status Register  */
+#define r_CORTEX_M_SCB_MMSR                 REG_ADDR(SCB_BASE + (uint32_t) 0x28)    /* (R/W)  MemManage Fault Address Register (A subregister of the CFSR) */
+#define r_CORTEX_M_SCB_BFSR                 REG_ADDR(SCB_BASE + (uint32_t) 0x29)    /* (R/W)  BusFault Status Register  */
+#define r_CORTEX_M_SCB_UFSR                 REG_ADDR(SCB_BASE + (uint32_t) 0x2a)    /* (R/W)  UsageFault Status Register  */
+
+#define r_CORTEX_M_SCB_HFSR                 REG_ADDR(SCB_BASE + (uint32_t) 0x2c)    /* (R/W)  Hard fault status register  */
+#define r_CORTEX_M_SCB_MMFAR                REG_ADDR(SCB_BASE + (uint32_t) 0x34)    /* (R/W)  Memory management fault address register */
+#define r_CORTEX_M_SCB_BFAR                 REG_ADDR(SCB_BASE + (uint32_t) 0x38)    /* (R/W)  Bus fault address register (BFAR) */
+#define r_CORTEX_M_SCB_AFSR                 REG_ADDR(SCB_BASE + (uint32_t) 0x3c)    /* (R/W)  Auxiliary fault status register */
+
+#define r_CORTEX_M_SCB_CPACR                REG_ADDR(SCB_BASE + (uint32_t) 0x88)    /* (R/W)  Coprocessor Access Control register */
+
+/* Auxiliary control register Définitions */
+#define SCB_ACTLR_DISOOFP_Pos               9   /* Bit 9 DISOOFP  */
+#define SCB_ACTLR_DISOOFP_Msk               ((uint32_t) 0x01 << SCB_ACTLR_DISOOFP_Pos)
+#define SCB_ACTLR_DISFPCA_Pos               8   /* Bit 8 DISFPCA  */
+#define SCB_ACTLR_DISFPCA_Msk               ((uint32_t) 0x01 << SCB_ACTLR_DISFPCA_Pos)
+#define SCB_ACTLR_DISFOLD_Pos               2   /* Bit 2 DISFOLD  */
+#define SCB_ACTLR_DISFOLD_Msk               ((uint32_t) 0x01 << SCB_ACTLR_DISFOLD_Pos)
+#define SCB_ACTLR_DISDEFWBUF_Pos            1   /* Bit 1 DISDEFWBUF   */
+#define SCB_ACTLR_DISDEFWBUF_Msk            ((uint32_t) 0x01 << SCB_ACTLR_DISDEFWBUF_Pos)
+#define SCB_ACTLR_DISMCYCINT_Pos            0   /* Bit 0 DISMCYCINT   */
+#define SCB_ACTLR_DISMCYCINT_Msk            ((uint32_t) 0x01 << SCB_ACTLR_DISMCYCINT_Pos)
+
+/* SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24   /* Bits 31:24 IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          ((uint32_t) 0x00ff << SCB_CPUID_IMPLEMENTER_Pos)
+
+#define SCB_CPUID_VARIANT_Pos              20   /* Bits 23:20 VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              ((uint32_t) 0x000f << SCB_CPUID_VARIANT_Pos)
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16   /* Bits 19:16 ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         ((uint32_t) 0x000f << SCB_CPUID_ARCHITECTURE_Pos)
+
+#define SCB_CPUID_PARTNO_Pos                4   /* Bits 15:4 PartNo Position */
+#define SCB_CPUID_PARTNO_Msk               ((uint32_t) 0x0fff << SCB_CPUID_PARTNO_Pos)
+
+#define SCB_CPUID_REVISION_Pos              0   /* Bits 3:0 Revision Position */
+#define SCB_CPUID_REVISION_Msk             ((uint32_t) 0x000f << SCB_CPUID_REVISION_Pos)
+
+/* SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_NMIPENDSET_Pos            31   /* Bit 31 NMIPENDSET:
+                                                   NMI set-pending bit position */
+#define SCB_ICSR_NMIPENDSET_Msk            ((uint32_t) 0x01 << SCB_ICSR_NMIPENDSET_Pos)
+
+#define SCB_ICSR_PENDSVSET_Pos             28   /* Bit 28 PENDSVSET:
+                                                   PendSV set-pending bit Position */
+#define SCB_ICSR_PENDSVSET_Msk             ((uint32_t) 0x01 << SCB_ICSR_PENDSVSET_Pos)
+
+#define SCB_ICSR_PENDSVCLR_Pos             27   /* Bit 27 PENDSVCLR:
+                                                   PendSV clear-pending bit Position */
+#define SCB_ICSR_PENDSVCLR_Msk             ((uint32_t) 0x01 << SCB_ICSR_PENDSVCLR_Pos)
+
+#define SCB_ICSR_PENDSTSET_Pos             26   /* Bit 26 PENDSTSET:
+                                                   SysTick exception set-pending bit Position */
+#define SCB_ICSR_PENDSTSET_Msk             ((uint32_t) 0x01 << SCB_ICSR_PENDSTSET_Pos)
+
+#define SCB_ICSR_PENDSTCLR_Pos             25   /* Bit 25 PENDSTCLR:
+                                                   SysTick exception clear-pending bit Position */
+#define SCB_ICSR_PENDSTCLR_Msk             ((uint32_t) 0x01 << SCB_ICSR_PENDSTCLR_Pos)
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23   /* Bit 23 ISRPREEMPT:
+                                                   reserved for Debug use and reads-as-zero when
+                                                   the processor is not in Debug */
+#define SCB_ICSR_ISRPREEMPT_Msk            ((uint32_t) 0x01 << SCB_ICSR_ISRPREEMPT_Pos)
+
+#define SCB_ICSR_ISRPENDING_Pos            22   /* Bit 22 ISRPENDING:
+                                                   Interrupt pending flag, excluding NMI and Faults */
+#define SCB_ICSR_ISRPENDING_Msk            ((uint32_t) 0x01 << SCB_ICSR_ISRPENDING_Pos)
+
+#define SCB_ICSR_VECTPENDING_Pos           12   /* Bits 18:12 VECTPENDING: Pending vector.
+                                                   Indicates the exception number of the highest priority
+                                                   pending enabled exception Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)
+
+#define SCB_ICSR_RETTOBASE_Pos             11   /* Bit 11 RETTOBASE: Return to base level.
+                                                   Indicates whether there are preempted active                                                                                                                          exceptions Position */
+#define SCB_ICSR_RETTOBASE_Msk             ((uint32_t) 0x01 << SCB_ICSR_RETTOBASE_Pos)
+
+#define SCB_ICSR_VECTACTIVE_Pos             0   /* Bits 8:0 VECTACTIVE Active vector.
+                                                   Contains the active exception number Position */
+#define SCB_ICSR_VECTACTIVE_Msk            ((uint32_t) 0x1FF << SCB_ICSR_VECTACTIVE_Pos)
+
+/* SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                9    /* Bits 29:9 TBLOFF: Vector table base offset field */
+#define SCB_VTOR_TBLOFF_Msk                ((uint32_t) 0x1fffff << SCB_VTOR_TBLOFF_Pos)
+
+/* SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16   /* Bits 31:16 VECTKEYSTAT/ VECTKEY Register key */
+#define SCB_AIRCR_VECTKEY_Msk              ((uint32_t) 0xFFFF << SCB_AIRCR_VECTKEY_Pos)
+
+#define SCB_AIRCR_ENDIANESS_Pos            15   /* Bit 15 ENDIANESS Data endianness bit */
+#define SCB_AIRCR_ENDIANESS_Msk            ((uint32_t) 0x01 << SCB_AIRCR_ENDIANESS_Pos)
+
+#define SCB_AIRCR_PRIGROUP_Pos              8   /* Bits 10:8 PRIGROUP: Interrupt priority grouping field  */
+#define SCB_AIRCR_PRIGROUP_Msk             ((uint32_t) 0x07 << SCB_AIRCR_PRIGROUP_Pos)
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2   /* Bit 2 SYSRESETREQ System reset request */
+#define SCB_AIRCR_SYSRESETREQ_Msk          ((uint32_t) 0x01 << SCB_AIRCR_SYSRESETREQ_Pos)
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1   /* Bit 1 VECTCLRACTIVE Reserved for Debug use.
+                                                   This bit reads as 0.
+                                                   When writing to the register you must write 0 to
+                                                   this bit, otherwise behavior is unpredictable. */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        ((uint32_t) 0x01 << SCB_AIRCR_VECTCLRACTIVE_Pos)
+
+#define SCB_AIRCR_VECTRESET_Pos             0   /* Bit 0 VECTRESET
+                                                   Reserved for Debug use.
+                                                   This bit reads as 0.
+                                                   When writing to the register you must write 0 to
+                                                   this bit, otherwise behavior is unpredictable. */
+#define SCB_AIRCR_VECTRESET_Msk            ((uint32_t) 0x01 << SCB_AIRCR_VECTRESET_Pos)
+
+/* SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4   /* Bit 4 SEVEONPEND Send Event on Pending bit */
+#define SCB_SCR_SEVONPEND_Msk              ((uint32_t) 0x01 << SCB_SCR_SEVONPEND_Pos)
+
+#define SCB_SCR_SLEEPDEEP_Pos               2   /* Bit 2 SLEEPDEEP  */
+#define SCB_SCR_SLEEPDEEP_Msk              ((uint32_t) 0x01 << SCB_SCR_SLEEPDEEP_Pos)
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1   /* Bit 1 SLEEPONEXIT  */
+#define SCB_SCR_SLEEPONEXIT_Msk            ((uint32_t) 0x01 << SCB_SCR_SLEEPONEXIT_Pos)
+
+/* SCB Configuration Control Register Definitions */
+#define SCB_CCR_STKALIGN_Pos                9   /* Bit 9 STKALIGN */
+#define SCB_CCR_STKALIGN_Msk               ((uint32_t) 0x01 << SCB_CCR_STKALIGN_Pos)
+
+#define SCB_CCR_BFHFNMIGN_Pos               8   /* Bit 8 BFHFNMIGN */
+#define SCB_CCR_BFHFNMIGN_Msk              ((uint32_t) 0x01 << SCB_CCR_BFHFNMIGN_Pos)
+
+#define SCB_CCR_DIV_0_TRP_Pos               4   /* Bit 4 DIV_0_TRP */
+#define SCB_CCR_DIV_0_TRP_Msk              ((uint32_t) 0x01 << SCB_CCR_DIV_0_TRP_Pos)
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3   /* Bit 3 UNALIGN_ TRP */
+#define SCB_CCR_UNALIGN_TRP_Msk            ((uint32_t) 0x01 << SCB_CCR_UNALIGN_TRP_Pos)
+
+#define SCB_CCR_USERSETMPEND_Pos            1   /* Bit 1 USERSETMPEND */
+#define SCB_CCR_USERSETMPEND_Msk           ((uint32_t) 0x01 << SCB_CCR_USERSETMPEND_Pos)
+
+#define SCB_CCR_NONBASETHRDENA_Pos          0   /* Bit 0 NONBASETHRDENA */
+#define SCB_CCR_NONBASETHRDENA_Msk         ((uint32_t) 0x01 << SCB_CCR_NONBASETHRDENA_Pos)
+
+//System handler priority register 1 (SHPR1)
+#define SCB_SHPR1_PRI_4_Pos                 0   /* Bits 7:0 PRI_4:
+                                                   Priority of system handler 4,
+                                                   memory management fault */
+#define SCB_SHPR1_PRI_4_Msk                 ((uint32_t) 0xff << SCB_SHPR1_PRI_4_Pos)
+
+#define SCB_SHPR1_PRI_5_Pos                 8   /* Bits 15:8 PRI_5:
+                                                   Priority of system handler 5, bus fault */
+#define SCB_SHPR1_PRI_5_Msk                 ((uint32_t) 0xff << SCB_SHPR1_PRI_5_Pos)
+
+//System handler priority register 2 (SHPR2)
+#define SCB_SHPR2_PRI_6_Pos                 16  /* Bits 23:16 PRI_6:
+                                                   Priority of system handler 6, usage fault */
+#define SCB_SHPR2_PRI_6_Msk                 ((uint32_t) 0xff << SCB_SHPR2_PRI_6_Pos)
+#define SCB_SHPR2_PRI_11_Pos                 24 /* Bits 31:24 PRI_11:
+                                                   Priority of system handler 11, SVCall */
+#define SCB_SHPR2_PRI_11_Msk                ((uint32_t) 0xff << SCB_SHPR2_PRI_11_Pos)
+
+//System handler priority register 3 (SHPR3)
+#define SCB_SHPR3_PRI_14_Pos                16  /* Bits 23:16 PRI_14:
+                                                   Priority of system handler 14, PendSV */
+#define SCB_SHPR3_PRI_14_Msk                ((uint32_t) 0xff << SCB_SHPR3_PRI_14_Pos)
+#define SCB_SHPR3_PRI_15_Pos                24  /* Bits 31:24 PRI_15:
+                                                   Priority of system handler 15, SysTick exception */
+#define SCB_SHPR3_PRI_15_Msk                ((uint32_t) 0xff << SCB_SHPR3_PRI_15_Pos)
+
+/* SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_USGFAULTENA_Pos          18   /* Bit 18 USGFAULTENA:
+                                                   Usage fault enable bit, set to 1 to enable */
+#define SCB_SHCSR_USGFAULTENA_Msk          ((uint32_t) 0x01 << SCB_SHCSR_USGFAULTENA_Pos)
+
+#define SCB_SHCSR_BUSFAULTENA_Pos          17   /* Bit 17 BUSFAULTENA:
+                                                   Bus fault enable bit, set to 1 to enabl */
+#define SCB_SHCSR_BUSFAULTENA_Msk          ((uint32_t) 0x01 << SCB_SHCSR_BUSFAULTENA_Pos)
+
+#define SCB_SHCSR_MEMFAULTENA_Pos          16   /* Bit 16 MEMFAULTENA:
+                                                   Memory management fault enable bit,
+                                                   set to 1 to enable */
+#define SCB_SHCSR_MEMFAULTENA_Msk          ((uint32_t) 0x01 << SCB_SHCSR_MEMFAULTENA_Pos)
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15   /* Bit 15 SVCALLPENDED:
+                                                   SVC call pending bit,
+                                                   reads as 1 if exception is pending */
+#define SCB_SHCSR_SVCALLPENDED_Msk         ((uint32_t) 0x01 << SCB_SHCSR_SVCALLPENDED_Pos)
+
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14   /* Bit 14 BUSFAULTPENDED:
+                                                   Bus fault exception pending bit,
+                                                   reads as 1 if exception is pending */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       ((uint32_t) 0x01 << SCB_SHCSR_BUSFAULTPENDED_Pos)
+
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13   /* Bit 13 MEMFAULTPENDED:
+                                                   Memory management fault exception pending bit,
+                                                   reads as 1 if exception is pending */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       ((uint32_t) 0x01 << SCB_SHCSR_MEMFAULTPENDED_Pos)
+
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12   /* Bit 12 USGFAULTPENDED:
+                                                   Usage fault exception pending bit,
+                                                   reads as 1 if exception is pending */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       ((uint32_t) 0x01 << SCB_SHCSR_USGFAULTPENDED_Pos)
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11   /* Bit 11 SYSTICKACT:
+                                                   SysTick exception active bit,
+                                                   reads as 1 if exception is active */
+#define SCB_SHCSR_SYSTICKACT_Msk           ((uint32_t) 0x01 << SCB_SHCSR_SYSTICKACT_Pos)
+
+#define SCB_SHCSR_PENDSVACT_Pos            10   /* Bit 10 PENDSVACT:
+                                                   PendSV exception active bit,
+                                                   reads as 1 if exception is activen */
+#define SCB_SHCSR_PENDSVACT_Msk            ((uint32_t) 0x01 << SCB_SHCSR_PENDSVACT_Pos)
+
+#define SCB_SHCSR_MONITORACT_Pos            8   /* Bit 8 MONITORACT:
+                                                   Debug monitor active bit,
+                                                   reads as 1 if Debug monitor is active */
+#define SCB_SHCSR_MONITORACT_Msk           ((uint32_t) 0x01 << SCB_SHCSR_MONITORACT_Pos)
+
+#define SCB_SHCSR_SVCALLACT_Pos             7   /* Bit 7 SVCALLACT:
+                                                   SVC call active bit,
+                                                   reads as 1 if SVC call is active */
+#define SCB_SHCSR_SVCALLACT_Msk            ((uint32_t) 0x01 << SCB_SHCSR_SVCALLACT_Pos)
+
+#define SCB_SHCSR_USGFAULTACT_Pos           3   /* Bit 3 USGFAULTACT:
+                                                   Usage fault exception active bit,
+                                                   reads as 1 if exception is active */
+#define SCB_SHCSR_USGFAULTACT_Msk          ((uint32_t) 0x01 << SCB_SHCSR_USGFAULTACT_Pos)
+
+#define SCB_SHCSR_BUSFAULTACT_Pos           1   /* Bit 1 BUSFAULTACT:
+                                                   Bus fault exception active bit,
+                                                   reads as 1 if exception is active */
+#define SCB_SHCSR_BUSFAULTACT_Msk          ((uint32_t) 0x01 << SCB_SHCSR_BUSFAULTACT_Pos)
+
+#define SCB_SHCSR_MEMFAULTACT_Pos           0   /* Bit 0 MEMFAULTACT:
+                                                   Memory management fault exception active bit,
+                                                   reads as 1 if exception is active */
+#define SCB_SHCSR_MEMFAULTACT_Msk          ((uint32_t) 0x01 << SCB_SHCSR_MEMFAULTACT_Pos)
+
+/* Configurable fault status register (CFSR; UFSR+BFSR+MMFSR)
+ * The CFSR is byte accessible. You can access the CFSR or its subregisters as follows:
+ * • Access the complete CFSR with a word access to 0xE000ED28
+ * • Access the MMFSR with a byte access to 0xE000ED28
+ * • Access the MMFSR and BFSR with a halfword access to 0xE000ED28
+ * • Access the BFSR with a byte access to 0xE000ED29
+ * • Access the UFSR with a halfword access to 0xE000ED2A.
+ *
+ * The CFSR indicates the cause of a memory management fault, bus fault, or usage fault.
+ */
+
+#define SCB_CFSR_UFSR_Pos                       16  /* Bits 31:16 UFSR:
+                                                       Usage fault status register (UFSR) */
+#define SCB_CFSR_UFSR_Msk                       ((uint32_t) 0xffff << SCB_CFSR_UFSR_Pos)
+#define SCB_CFSR_BFSR_Pos                       8   /* Bits 15:8 BFSR:
+                                                       Bus fault status register (BFSR) */
+#define SCB_CFSR_BFSR_Msk                       ((uint32_t) 0xff << SCB_CFSR_BFSR_Pos)
+#define SCB_CFSR_MMFSR_Pos                      0   /* Bits 7:0 MMFSR:
+                                                       Memory management fault address register (MMFSR) */
+#define SCB_CFSR_MMFSR_Msk                      ((uint32_t) 0xff << SCB_CFSR_MMFSR_Pos)
+
+ /* Usage fault status register (UFSR) */
+#define SCB_CFSR_UFSR_DIVBYZERO_Pos              25 /* Bit 25 DIVBYZERO:
+                                                       Divide by zero usage fault. */
+#define SCB_CFSR_UFSR_DIVBYZERO_Msk              ((uint32_t) 0x01 << SCB_UFSR_DIVBYZERO_Pos)
+#define SCB_CFSR_UFSR_UNALIGNED_Pos              24 /* Bit 24 UNALIGNED:
+                                                       Unaligned access usage fault. */
+#define SCB_CFSR_UFSR_UNALIGNED_Msk              ((uint32_t) 0x01 << SCB_UFSR_UNALIGNED_Pos)
+#define SCB_CFSR_UFSR_NOCP_Pos                   19 /* Bit 19 NOCP:
+                                                       No coprocessor usage fault. */
+#define SCB_CFSR_UFSR_NOCP_Msk                   ((uint32_t) 0x01 << SCB_UFSR_NOCP_Pos)
+#define SCB_CFSR_UFSR_INVPC_Pos                  18 /* Bit 18 INVPC:
+                                                       Invalid PC load usage fault,
+                                                       caused by an invalid PC load by EXC_RETURN */
+#define SCB_CFSR_UFSR_INVPC_Msk                  ((uint32_t) 0x01 << SCB_UFSR_INVPC_Pos)
+#define SCB_CFSR_UFSR_INVSTATE_Pos               17 /* Bit 17 INVSTATE:
+                                                       Invalid state usage fault. */
+#define SCB_CFSR_UFSR_INVSTATE_Msk               ((uint32_t) 0x01 << SCB_UFSR_INVSTATE_Pos)
+#define SCB_CFSR_UFSR_UNDEFINSTR_Pos             16 /* Bit 16 UNDEFINSTR:
+                                                       Undefined instruction usage fault. */
+#define SCB_CFSR_UFSR_UNDEFINSTR_Msk             ((uint32_t) 0x01 << SCB_UFSR_UNDEFINSTR_Pos)
+
+/* Bus fault status register (BFSR) */
+#define SCB_CFSR_BFSR_BFARVALID_Pos              15 /* Bit 15 BFARVALID:
+                                                       Bus Fault Address Register (BFAR) valid flag.
+                                                       The processor sets this bit to 1 */
+#define SCB_CFSR_BFSR_BFARVALID_Msk              ((uint32_t) 0x01 << SCB_BFSR_BFARVALID_Pos)
+#define SCB_CFSR_BFSR_LSPERR_Pos                 13 /* Bit 13 LSPERR:
+                                                       Bus fault on floating-point lazy state preservation. */
+#define SCB_CFSR_BFSR_LSPERR_Msk                 ((uint32_t) 0x01 << SCB_BFSR_LSPERR_Pos)
+#define SCB_CFSR_BFSR_STKERR_Pos                 12 /* Bit 12 STKERR:
+                                                       Bus fault on stacking for exception entry. */
+#define SCB_CFSR_BFSR_STKERR_Msk                 ((uint32_t) 0x01 << SCB_BFSR_STKERR_Pos)
+#define SCB_CFSR_BFSR_UNSTKERR_Pos               11 /* Bit 11 UNSTKERR:
+                                                       Bus fault on unstacking for a return from exception. */
+#define SCB_CFSR_BFSR_UNSTKERR_Msk               ((uint32_t) 0x01 << SCB_BFSR_UNSTKERR_Pos)
+#define SCB_CFSR_BFSR_IMPRECISERR_Pos            10 /* Bit 10 IMPRECISERR:
+                                                       Imprecise data bus error. */
+#define SCB_CFSR_BFSR_IMPRECISERR_Msk            ((uint32_t) 0x01 << SCB_BFSR_IMPRECISERR_Pos)
+#define SCB_CFSR_BFSR_PRECISERR_Pos              9  /* Bit 9 PRECISERR:
+                                                       Precise data bus error. */
+#define SCB_CFSR_BFSR_PRECISERR_Msk              ((uint32_t) 0x01 << SCB_BFSR_PRECISERR_Pos)
+#define SCB_CFSR_BFSR_IBUSERR_Pos                8  /* Bit 8 IBUSERR:
+                                                       Instruction bus error. */
+#define SCB_CFSR_BFSR_IBUSERR_Msk                ((uint32_t) 0x01 << SCB_BFSR_IBUSERR_Pos)
+
+/* Memory management fault address register (MMFSR)*/
+#define SCB_CFSR_MMFSR_MMARVALID_Pos             7  /* Bit 7 MMARVALID:
+                                                       Memory Management Fault Address Register (MMAR) valid flag. */
+#define SCB_CFSR_MMFSR_MMARVALID_Msk             ((uint32_t) 0x01 << SCB_CFSR_MMFSR_MMARVALID_Pos)
+#define SCB_CFSR_MMFSR_MLSPERR_Pos               5  /* Bit 5 MLSPERR:
+                                                       MemManage fault  status */
+#define SCB_CFSR_MMFSR_MLSPERR_Msk               ((uint32_t) 0x01 << SCB_CFSR_MMFSR_MLSPERR_Pos)
+#define SCB_CFSR_MMFSR_MSTKERR_Pos               4  /* Bit 4 MSTKERR:
+                                                       Memory manager fault on stacking for exception entry. */
+#define SCB_CFSR_MMFSR_MSTKERR_Msk               ((uint32_t) 0x01 << SCB_CFSR_MMFSR_MSTKERR_Pos)
+#define SCB_CFSR_MMFSR_MUNSTKERR_Pos             3  /* Bit 3 MUNSTKERR:
+                                                       Memory manager fault on unstacking
+                                                       for a return from exception. */
+#define SCB_CFSR_MMFSR_MUNSTKERR_Msk             ((uint32_t) 0x01 << SCB_CFSR_MMFSR_MUNSTKERR_Pos)
+#define SCB_CFSR_MMFSR_DACCVIOL_Pos              1  /* Bit 1 DACCVIOL:
+                                                       Data access violation flag. */
+#define SCB_CFSR_MMFSR_DACCVIOL_Msk              ((uint32_t) 0x01 << SCB_CFSR_MMFSR_DACCVIOL_Pos)
+
+#define SCB_CFSR_MMFSR_IACCVIOL_Pos              0  /* Bit 0 IACCVIOL:
+                                                       Instruction access violation flag.
+                                                       This fault occurs on any access to an XN region */
+#define SCB_CFSR_MMFSR_IACCVIOL_Msk              ((uint32_t) 0x01 << SCB_CFSR_MMFSR_Pos)
+
+/* Hard fault status register (HFSR)*/
+#define SCB_HFSR_DEBUG_VT_Pos                   31  /*  Bit 31 DEBUG_VT:
+                                                       Reserved for Debug use.
+                                                       When writing to the register you must write 0 to this bit */
+#define SCB_HFSR_DEBUG_VT_Msk              ((uint32_t) 0x01 << SCB_HFSR_DEBUG_VT_Pos)
+
+#define SCB_HFSR_FORCED_Pos                30   /*  Bit 30 FORCED:
+                                                   Forced hard fault.
+                                                   Indicates a forced hard fault,
+                                                   generated by escalation of a fault */
+#define SCB_HFSR_FORCED_Msk                ((uint32_t) 0x01 << SCB_HFSR_FORCED_Pos)
+
+#define SCB_HFSR_VECTTBL_Pos               1    /*  Bit 1 VECTTBL:
+                                                   Vector table hard fault.
+                                                   Indicates a bus fault on a vector table read during */
+#define SCB_HFSR_VECTTBL_Msk               ((uint32_t) 0x01 << SCB_HFSR_VECTTBL_Pos)
+
+/* Memory management fault address register (MMFAR) */
+#define SCB_MMFAR_Pos                       0   /* Bits 31:0 MMFAR: Memory management fault address */
+#define SCB_MMFAR_Msk                       ((uint32_t) 0xffffffff << SCB_MMFAR_Pos)
+
+/* Bus fault address register (BFAR) */
+#define SCB_BFAR_Pos                        0   /* Bits 31:0 Bus fault address
+                                                   When the BFARVALID bit of the BFSR is set to 1,
+                                                   this field holds the address f the location that
+                                                   generated the bus fault. When an unaligned access faults
+                                                   the address in the BFAR is the one requested by the instruction,
+                                                   even if it is not the adress of the fault. */
+#define SCB_BFAR_Msk                        ((uint32_t) 0xffffffff << SCB_BFAR_Pos)
+
+/* Auxiliary fault status register (AFSR) */
+#define SCB_AFSR_IMPDEF_Pos                  0  /* Bits 31:0 IMPDEF:
+                                                   Implementation defined.
+                                                   The AFSR contains additional system fault information. */
+#define SCB_AFSR_IMPDEF_Msk                  ((uint32_t) 0xffffffff << SCB_AFSR_IMPDEF_Pos)
+#endif /* SOC_SCB_H */

--- a/src/arch/socs/stm32f439/soc-scb.h
+++ b/src/arch/socs/stm32f439/soc-scb.h
@@ -1,24 +1,35 @@
-/* \file soc-scb.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef SOC_SCB_H
 #define SOC_SCB_H

--- a/src/arch/socs/stm32f439/soc-usart-regs.h
+++ b/src/arch/socs/stm32f439/soc-usart-regs.h
@@ -1,26 +1,36 @@
-/* \file soc-usart-regs.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
-
 #ifndef SOC_USART_REGS_H
 #define SOC_USART_REGS_H
 

--- a/src/arch/socs/stm32f439/soc-usart-regs.h
+++ b/src/arch/socs/stm32f439/soc-usart-regs.h
@@ -1,0 +1,433 @@
+/* \file soc-usart-regs.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#ifndef SOC_USART_REGS_H
+#define SOC_USART_REGS_H
+
+#include "soc-core.h"
+
+/* Add some aliases for UART4 and UART 5 */
+#define USART4_BASE	UART4_BASE
+#define USART5_BASE	UART5_BASE
+
+#define _r_CORTEX_M_USART_SR(n)		REG_ADDR(USART ## n ## _BASE + 0x00)
+#define _r_CORTEX_M_USART_DR(n)		REG_ADDR(USART ## n ## _BASE + 0x04)
+#define _r_CORTEX_M_USART_BRR(n)	REG_ADDR(USART ## n ## _BASE + 0x08)
+#define _r_CORTEX_M_USART_CR1(n)	REG_ADDR(USART ## n ## _BASE + 0x0c)
+#define _r_CORTEX_M_USART_CR2(n)	REG_ADDR(USART ## n ## _BASE + 0x10)
+#define _r_CORTEX_M_USART_CR3(n)	REG_ADDR(USART ## n ## _BASE + 0x14)
+#define _r_CORTEX_M_USART_GTPR(n)	REG_ADDR(USART ## n ## _BASE + 0x18)
+
+/***** Status register *****/
+/* Bit 0 PE: Parity error */
+#define USART_SR_PE_Pos		0
+#define USART_SR_PE_Msk		((uint32_t)1 << USART_SR_PE_Pos)
+#define USART_SR_PE_OK  	((uint32_t)0 << USART_SR_PE_Pos)
+#define USART_SR_PE_ERROR      	((uint32_t)1 << USART_SR_PE_Pos)
+
+/* Bit 1 FE: Framing error */
+#define USART_SR_FE_Pos		1
+#define USART_SR_FE_Msk		((uint32_t)1 << USART_SR_FE_Pos)
+#define USART_SR_FE_OK         ((uint32_t)0 << USART_SR_FE_Pos)
+#define USART_SR_FE_ERROR      ((uint32_t)1 << USART_SR_FE_Pos)
+
+/* Bit 2 NF: Noise detected flag */
+#define USART_SR_NF_Pos		2
+#define USART_SR_NF_Msk		((uint32_t)1 << USART_SR_NF_Pos)
+#define USART_SR_NF_OK         ((uint32_t)0 << USART_SR_NF_Pos)
+#define USART_SR_NF_ERROR      ((uint32_t)1 << USART_SR_NF_Pos)
+
+/* Bit 3 ORE: Overrun error */
+#define USART_SR_OVERRUN_Pos	3
+#define USART_SR_OVERRUN_Msk	((uint32_t)1 << USART_SR_OVERRUN_Pos)
+#define USART_SR_OVERRUN_OK    ((uint32_t)0 << USART_SR_OVERRUN_Pos)
+#define USART_SR_OVERRUN_ERROR ((uint32_t)1 << USART_SR_OVERRUN_Pos)
+
+/* Bit 4 IDLE: IDLE line detected */
+#define USART_SR_IDLE_Pos		4
+#define USART_SR_IDLE_Msk		((uint32_t)1 << USART_SR_IDLE_Pos)
+#define USART_SR_IDLE_NO_IDLE  ((uint32_t)0 << USART_SR_IDLE_Pos)
+#define USART_SR_IDLE_IDLE     ((uint32_t)1 << USART_SR_IDLE_Pos)
+
+#define USART_SR_RXNE_Pos		5
+#define USART_SR_RXNE_Msk		((uint32_t)1 << USART_SR_RXNE_Pos)
+#define USART_SR_RXNE_EMPTY	((uint32_t)0 << USART_SR_RXNE_Pos)
+#define USART_SR_RXNE_RDY		((uint32_t)1 << USART_SR_RXNE_Pos)
+
+/* Bit 6 TC: Transmission complete */
+#define USART_SR_TC_Pos		6
+#define USART_SR_TC_Msk		((uint32_t)1 << USART_SR_TC_Pos)
+#define USART_SR_TC_RUNNING    ((uint32_t)0 << USART_SR_TC_Pos)
+#define USART_SR_TC_COMPLETE   ((uint32_t)1 << USART_SR_TC_Pos)
+
+/* Bit 6 TC: Transmission complete */
+#define USART_SR_TXE_Pos		7
+#define USART_SR_TXE_Msk		((uint32_t)1 << USART_SR_TXE_Pos)
+#define USART_SR_TXE_DATA_NOT_TRANSFERED   ((uint32_t)0 << USART_SR_TXE_Pos)
+#define USART_SR_TXE_DATA_TRANSFERED       ((uint32_t)1 << USART_SR_TXE_Pos)
+
+/* Bit 8 LBD: LIN break detection flag */
+#define USART_SR_LIN_Pos	   8
+#define USART_SR_LIN_Msk	   ((uint32_t)1 << USART_SR_LIN_Pos)
+#define USART_SR_LIN_NO_LINE_BREAK ((uint32_t)0 << USART_SR_LIN_Pos)
+#define USART_SR_LIN_LINE_BREAK    ((uint32_t)1 << USART_SR_LIN_Pos)
+
+/* Bit 9 CTS: CTS flag */
+#define USART_SR_CTS_Pos	9
+#define USART_SR_CTS_Msk	((uint32_t)1 << USART_SR_CTS_Pos)
+#define USART_SR_CTS_NO_CHANGE ((uint32_t)0 << USART_SR_CTS_Pos)
+#define USART_SR_CTS_CHANGED   ((uint32_t)1 << USART_SR_CTS_Pos)
+
+/***** Data register *****/
+/* Bits 8:0 DR[8:0]: Data value */
+#define USART_DR_DR_Pos		0
+#define USART_DR_DR_Msk		((uint32_t)0xff << USART_DR_DR_Pos)
+
+/* Baud rate register */
+/* Bits 3:0 DIV_Fraction[3:0]: fraction of USARTDIV */
+#define USART_BRR_FRACTION_Pos	0
+#define USART_BRR_FRACTION_Msk	((uint32_t)0xf << USART_BRR_FRACTION_Pos)
+
+/* Bits 15:4 DIV_Mantissa[11:0]: mantissa of USARTDIV */
+#define USART_BRR_MANTISSA_Pos	4
+#define USART_BRR_MANTISSA_Msk	((uint32_t)0xfff << USART_BRR_MANTISSA_Pos)
+
+/***** Control register 1 *****/
+/* Bit 0 SBK: Send break */
+#define USART_CR1_SBK_Pos      0
+#define USART_CR1_SBK_Msk      ((uint32_t)1 << USART_CR1_SBK_Pos)
+
+/* Bit 1 RWU: Receiver wakeup */
+#define USART_CR1_RWU_Pos      1
+#define USART_CR1_RWU_Msk      ((uint32_t)1 << USART_CR1_RWU_Pos)
+
+/* Bit 2 RE: Receiver enable */
+#define USART_CR1_RE_Pos	2
+#define USART_CR1_RE_Msk	((uint32_t)1 << USART_CR1_RE_Pos)
+#define USART_CR1_RE_EN		((uint32_t)1 << USART_CR1_RE_Pos)
+#define USART_CR1_RE_DIS	((uint32_t)0 << USART_CR1_RE_Pos)
+
+/* Bit 3 TE: Transmitter enable */
+#define USART_CR1_TE_Pos	3
+#define USART_CR1_TE_Msk	((uint32_t)1 << USART_CR1_TE_Pos)
+#define USART_CR1_TE_EN		((uint32_t)1 << USART_CR1_TE_Pos)
+#define USART_CR1_TE_DIS	((uint32_t)0 << USART_CR1_TE_Pos)
+
+/* Bit 4 IDLEIE: IDLE interrupt enable */
+#define USART_CR1_IDLEIE_Pos	5
+#define USART_CR1_IDLEIE_Msk	((uint32_t)1 << USART_CR1_IDLEIE_Pos)
+
+/* Bit 5 RXNEIE: RXNE interrupt enable */
+#define USART_CR1_RXNEIE_Pos	5
+#define USART_CR1_RXNEIE_Msk	((uint32_t)1 << USART_CR1_RXNEIE_Pos)
+
+/* Bit 6 TCIE: Transmission complete interrupt enable */
+#define USART_CR1_TCIE_Pos     6
+#define USART_CR1_TCIE_Msk     ((uint32_t)1 << USART_CR1_TCIE_Pos)
+
+/* Bit 7 TXEIE: TXE interrupt enable */
+#define USART_CR1_TXEIE_Pos    7
+#define USART_CR1_TXEIE_Msk    ((uint32_t)1 << USART_CR1_TXEIE_Pos)
+
+/* Bit 8 PEIE: PE interrupt enable */
+#define USART_CR1_PEIE_Pos     8
+#define USART_CR1_PEIE_Msk     ((uint32_t)1 << USART_CR1_PEIE_Pos)
+#define USART_CR1_PEIE_DIS     ((uint32_t)0 << USART_CR1_PEIE_Pos)
+#define USART_CR1_PEIE_EN      ((uint32_t)1 << USART_CR1_PEIE_Pos)
+
+/* Bit 9 PS: Parity selection */
+#define USART_CR1_PS_Pos       9
+#define USART_CR1_PS_Msk       ((uint32_t)1 << USART_CR1_PS_Pos)
+#define USART_CR1_PS_EVEN      ((uint32_t)0 << USART_CR1_PS_Pos)
+#define USART_CR1_PS_ODD       ((uint32_t)1 << USART_CR1_PS_Pos)
+
+/* Bit 10 PCE: Parity control enable */
+#define USART_CR1_PCE_Pos      10
+#define USART_CR1_PCE_Msk      ((uint32_t)1 << USART_CR1_PCE_Pos)
+#define USART_CR1_PCE_EN       ((uint32_t)1 << USART_CR1_PCE_Pos)
+#define USART_CR1_PCE_DIS      ((uint32_t)0 << USART_CR1_PCE_Pos)
+
+/* Bit 11 WAKE: Wakeup method */
+#define USART_CR1_WAKE_Pos      11
+#define USART_CR1_WAKE_Msk      ((uint32_t)1 << USART_CR1_WAKE_Pos)
+
+/* Bit 12 M: Word length */
+#define USART_CR1_M_Pos		12
+#define USART_CR1_M_Msk		((uint32_t)1 << USART_CR1_M_Pos)
+#define USART_CR1_M_8		((uint32_t)0 << USART_CR1_M_Pos)
+#define USART_CR1_M_9		((uint32_t)1 << USART_CR1_M_Pos)
+
+/* Bit 13 UE: USART enable */
+#define USART_CR1_UE_Pos	13
+#define USART_CR1_UE_Msk	((uint32_t)1 << USART_CR1_UE_Pos)
+#define USART_CR1_UE_DIS       	((uint32_t)0 << USART_CR1_UE_Pos)
+#define USART_CR1_UE_EN        	((uint32_t)1 << USART_CR1_UE_Pos)
+
+/* Bit 15 OVER8: Over sampling */
+#define USART_CR1_OVER8_Pos    	15
+#define USART_CR1_OVER8_Msk    	((uint32_t)1 << USART_CR1_OVER8_Pos)
+#define USART_CR1_OVER_S_8   	((uint32_t)0 << USART_CR1_OVER8_Pos)
+#define USART_CR1_OVER_S_16  	((uint32_t)1 << USART_CR1_OVER8_Pos)
+
+/***** Control register 2 *****/
+/* Bit 14 LINEN: LIN mode enable */
+#define USART_CR2_LINEN_Pos      14
+#define USART_CR2_LINEN_Msk      ((uint32_t)1 << USART_CR2_LINEN_Pos)
+#define USART_CR2_LINEN_DIS      ((uint32_t)0 << USART_CR2_LINEN_Pos)
+#define USART_CR2_LINEN_EN       ((uint32_t)1 << USART_CR2_LINEN_Pos)
+
+/* Bits 13:12 STOP: STOP bits */
+#define USART_CR2_STOP_Pos	12
+#define USART_CR2_STOP_Msk	((uint32_t)3 << USART_CR2_STOP_Pos)
+#define USART_CR2_STOP_1BIT	0   /* 1 Stop bit     */
+#define USART_CR2_STOP_0_5BITS	1   /* 0.5 Stop bit   */
+#define USART_CR2_STOP_2BITS	2   /* 2 Stop bit     */
+#define USART_CR2_STOP_1_5BITS	3   /* 1.5 Stop bit   */
+
+/* Bit 11 CLKEN: Clock enable */
+#define USART_CR2_CLKEN_Pos     11
+#define USART_CR2_CLKEN_Msk     ((uint32_t)1 << USART_CR2_CLKEN_Pos)
+#define USART_CR2_CLKEN_PIN_EN  ((uint32_t)1 << USART_CR2_CLKEN_Pos)
+#define USART_CR2_CLKEN_PIN_DIS ((uint32_t)0 << USART_CR2_CLKEN_Pos)
+
+/* Bit 10 CPOL: Clock polarity */
+#define USART_CR2_CPOL_Pos  	10
+#define USART_CR2_CPOL_Msk  	((uint32_t)1 << USART_CR2_CPOL_Pos)
+#define USART_CR2_CPOL_EN  	((uint32_t)1 << USART_CR2_CPOL_Pos)
+#define USART_CR2_CPOL_DIS  	((uint32_t)0 << USART_CR2_CPOL_Pos)
+
+/* Bit 9 CPHA: Clock phase */
+#define USART_CR2_CPHA_Pos  	9
+#define USART_CR2_CPHA_Msk  	((uint32_t)1 << USART_CR2_CPHA_Pos)
+#define USART_CR2_CPHA_EN  	((uint32_t)1 << USART_CR2_CPHA_Pos)
+#define USART_CR2_CPHA_DIS 	((uint32_t)0 << USART_CR2_CPHA_Pos)
+
+/* Bit 8 LBCL: Last bit clock pulse */
+#define USART_CR2_LBCL_Pos  	8
+#define USART_CR2_LBCL_Msk  	((uint32_t)1 << USART_CR2_LBCL_Pos)
+#define USART_CR2_LBCL_DIS  	((uint32_t)0 << USART_CR2_LBCL_Pos)
+#define USART_CR2_LBCL_EN   	((uint32_t)1 << USART_CR2_LBCL_Pos)
+
+/* Bit 6 LBDIE: LIN break detection interrupt enable */
+#define USART_CR2_LBDIE_Pos 	6
+#define USART_CR2_LBDIE_Msk 	((uint32_t)1 << USART_CR2_LBDIE_Pos)
+#define USART_CR2_LBDIE_EN  	((uint32_t)1 << USART_CR2_LBDIE_Pos)    /* An interrupt is generated whenever LBD=1 in the USART_SR register */
+#define USART_CR2_LBDIE_DIS 	((uint32_t)0 << USART_CR2_LBDIE_Pos)    /*  Interrupt is inhibited */
+
+/* Bit 5 LBDL: lin break detection length */
+#define USART_CR2_LBDL_Pos  	5
+#define USART_CR2_LBDL_Msk  	((uint32_t)1 << USART_CR2_LBDL_Pos)
+#define USART_CR2_LBDL_10   	((uint32_t)0 << USART_CR2_LBDL_Pos)
+#define USART_CR2_LBDL_11   	((uint32_t)1 << USART_CR2_LBDL_Pos)
+
+/* Bits 3:0 ADD[3:0]: Address of the USART node */
+#define USART_CR2_ADD_Pos  	0
+#define USART_CR2_ADD_Msk  	((uint32_t)4 << USART_CR2_ADD_Pos)
+
+/***** Control register 3 ******/
+/* Bit 11 ONEBIT: One sample bit method enable */
+#define USART_CR3_ONEBIT_Pos   11
+#define USART_CR3_ONEBIT_Msk   ((uint32_t)1 << USART_CR3_ONEBIT_Pos)
+#define USART_CR3_ONEBIT_3_SPL_BIT ((uint32_t)0 << USART_CR3_ONEBIT_Pos)
+#define USART_CR3_ONEBIT_1_SPL_BIT ((uint32_t)1 << USART_CR3_ONEBIT_Pos)
+
+/* Bit 10 CTSIE: CTS interrupt enable */
+#define USART_CR3_CTSIE_Pos    10
+#define USART_CR3_CTSIE_Msk    ((uint32_t)1 << USART_CR3_CTSIE_Pos)
+#define USART_CR3_CTSIE_DIS    ((uint32_t)0 << USART_CR3_CTSIE_Pos)
+#define USART_CR3_CTSIE_EN     ((uint32_t)1 << USART_CR3_CTSIE_Pos)
+
+/* Bit 9 CTSE: CTS enable */
+/* Note: This bit is not available for UART4 & UART5. */
+#define USART_CR3_CTSE_Pos     9
+#define USART_CR3_CTSE_Msk     ((uint32_t)1 << USART_CR3_CTSE_Pos)
+#define USART_CR3_CTSE_CTS_DIS ((uint32_t)0 << USART_CR3_CTSE_Pos)
+#define USART_CR3_CTSE_CTS_EN  ((uint32_t)1 << USART_CR3_CTSE_Pos)
+
+/* Bit 8 RTSE: RTS enable */
+/* Note: This bit is not available for UART4 & UART5. */
+#define USART_CR3_RTSE_Pos     8
+#define USART_CR3_RTSE_Msk     ((uint32_t)1 << USART_CR3_RTSE_Pos)
+#define USART_CR3_RTSE_RTS_DIS ((uint32_t)0 << USART_CR3_RTSE_Pos)
+#define USART_CR3_RTSE_RTS_EN  ((uint32_t)1 << USART_CR3_RTSE_Pos)
+
+/* Bit 7 DMAT: DMA enable transmitter */
+#define USART_CR3_DMAT_Pos		7
+#define USART_CR3_DMAT_Msk		((uint32_t)1 << USART_CR3_DMAT_Pos)
+#define USART_CR3_DMAT_DIS		((uint32_t)0 << USART_CR3_DMAT_Pos)
+#define USART_CR3_DMAT_EN		((uint32_t)1 << USART_CR3_DMAT_Pos)
+
+/* Bit 6 DMAR: DMA enable receiver */
+#define USART_CR3_DMAR_Pos		6
+#define USART_CR3_DMAR_Msk		((uint32_t)1 << USART_CR3_DMAR_Pos)
+#define USART_CR3_DMAR_DIS		((uint32_t)0 << USART_CR3_DMAR_Pos)
+#define USART_CR3_DMAR_EN		((uint32_t)1 << USART_CR3_DMAR_Pos)
+
+/* Bit 5 SCEN: Smartcard mode enable */
+/* Note: This bit is not available for UART4 & UART5. */
+#define USART_CR3_SCEN_Pos     5
+#define USART_CR3_SCEN_Msk     ((uint32_t)1 << USART_CR3_SCEN_Pos)
+#define USART_CR3_SCEN_DIS     ((uint32_t)0 << USART_CR3_SCEN_Pos)
+#define USART_CR3_SCEN_EN      ((uint32_t)1 << USART_CR3_SCEN_Pos)
+
+/* Bit 4 NACK: Smartcard NACK enable */
+/* Note: This bit is not available for UART4 & UART5. */
+#define USART_CR3_NACK_Pos     4
+#define USART_CR3_NACK_Msk     ((uint32_t)1 << USART_CR3_NACK_Pos)
+#define USART_CR3_NACK_DIS     ((uint32_t)0 << USART_CR3_NACK_Pos)
+#define USART_CR3_NACK_EN      ((uint32_t)1 << USART_CR3_NACK_Pos)
+
+/* Bit 3 HDSEL: Half-duplex selection */
+#define USART_CR3_HDSEL_Pos    3
+#define USART_CR3_HDSEL_Msk    ((uint32_t)1 << USART_CR3_HDSEL_Pos)
+#define USART_CR3_HDSEL_DIS    ((uint32_t)0 << USART_CR3_HDSEL_Pos)
+#define USART_CR3_HDSEL_EN     ((uint32_t)1 << USART_CR3_HDSEL_Pos)
+
+/* Bit 2 IRLP: IrDA low-power */
+#define USART_CR3_IRLP_Pos     2
+#define USART_CR3_IRLP_Msk     ((uint32_t)1 << USART_CR3_IRLP_Pos)
+#define USART_CR3_IRLP_NORMAL  ((uint32_t)0 << USART_CR3_IRLP_Pos)
+#define USART_CR3_IRLP_LOW_POWER ((uint32_t)1 << USART_CR3_IRLP_Pos)
+
+/* Bit 1 IREN: IrDA mode enable */
+#define USART_CR3_IREN_Pos     1
+#define USART_CR3_IREN_Msk     ((uint32_t)1 << USART_CR3_IREN_Pos)
+#define USART_CR3_IREN_DIS     ((uint32_t)0 << USART_CR3_IREN_Pos)
+#define USART_CR3_IREN_EN      ((uint32_t)1 << USART_CR3_IREN_Pos)
+
+/* Bit 0 EIE: Error interrupt enable */
+#define USART_CR3_EIE_Pos      0
+#define USART_CR3_EIE_Msk      ((uint32_t)1 << USART_CR3_EIE_Pos)
+#define USART_CR3_EIE_DIS      ((uint32_t)0 << USART_CR3_EIE_Pos)
+#define USART_CR3_EIE_EN       ((uint32_t)1 << USART_CR3_EIE_Pos)
+
+/***** Guard time and prescaler register (USART_GTPR) ******/
+/* Bits 15:8 GT[7:0]: Guard time value */
+#define USART_GTPR_GT_Pos   8
+#define USART_GTPR_GT_Msk   ((uint32_t)(0xff) << USART_GTPR_GT_Pos)
+
+/* Bits 7:0 PSC[7:0]: Prescaler value */
+#define USART_GTPR_PSC_Pos   0
+#define USART_GTPR_PSC_Msk   ((uint32_t)(0xff) << USART_GTPR_PSC_Pos)
+/*
+n IrDA Low-power mode:
+PSC[7:0] = IrDA Low-Power Baud Rate
+Used for programming the prescaler for dividing the system clock to achieve the low-power
+frequency:
+The source clock is divided by the value given in the register (8 significant bits):
+00000000: Reserved - do not program this value
+00000001: divides the source clock by 1
+00000010: divides the source clock by 2
+...
+ */
+#define USART_GTPR_PSC_IRDA_LOW_DIV1 		((uint32_t)(0x1) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_IRDA_LOW_DIV2 		((uint32_t)(0x2) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_IRDA_LOW_DIV4 		((uint32_t)(0x4) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_IRDA_LOW_DIV8		((uint32_t)(0x8) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_IRDA_LOW_DIV16		((uint32_t)(0x10) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_IRDA_LOW_DIV32		((uint32_t)(0x20) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_IRDA_LOW_DIV64		((uint32_t)(0x40) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_IRDA_LOW_DIV128		((uint32_t)(0x80) << USART_GTPR_PSC_Pos)
+/*
+In normal IrDA mode: PSC must be set to 00000001.
+ */
+#define USART_GTPR_PSC_IRDA_HIGH_DIV		((uint32_t)(0x1) << USART_GTPR_PSC_Pos)
+/*
+In smartcard mode:
+PSC[4:0]: Prescaler value
+Used for programming the prescaler for dividing the system clock to provide the smartcard
+clock.
+The value given in the register (5 significant bits) is multiplied by 2 to give the division factor
+of the source clock frequency:
+00000: Reserved - do not program this value
+00001: divides the source clock by 2
+00010: divides the source clock by 4
+00011: divides the source clock by 6
+...
+ */
+#define USART_GTPR_PSC_SMARTCARD_DIV2		((uint32_t)(0x1) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV4		((uint32_t)(0x2) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV6		((uint32_t)(0x3) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV8		((uint32_t)(0x4) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV10		((uint32_t)(0x5) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV12		((uint32_t)(0x6) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV14		((uint32_t)(0x7) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV16		((uint32_t)(0x8) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV18		((uint32_t)(0x8) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV20		((uint32_t)(0xa) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV22		((uint32_t)(0xb) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV24		((uint32_t)(0xc) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV26		((uint32_t)(0xd) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV28		((uint32_t)(0xe) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV30		((uint32_t)(0xf) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV32		((uint32_t)(0x10) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV34		((uint32_t)(0x11) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV36		((uint32_t)(0x12) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV38		((uint32_t)(0x13) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV40		((uint32_t)(0x14) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV42		((uint32_t)(0x15) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV44		((uint32_t)(0x16) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV46		((uint32_t)(0x17) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV48		((uint32_t)(0x18) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV50		((uint32_t)(0x19) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV52		((uint32_t)(0x1a) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV54		((uint32_t)(0x1b) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV56		((uint32_t)(0x1c) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV58		((uint32_t)(0x1d) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV60		((uint32_t)(0x1e) << USART_GTPR_PSC_Pos)
+#define USART_GTPR_PSC_SMARTCARD_DIV62		((uint32_t)(0x1f) << USART_GTPR_PSC_Pos)
+
+#define USART_GET_REGISTER(reg)\
+static inline volatile uint32_t* r_CORTEX_M_USART_##reg (uint8_t n){\
+	switch(n){\
+		case 1:\
+			return _r_CORTEX_M_USART_##reg(1);\
+			break;\
+		case 2:\
+			return _r_CORTEX_M_USART_##reg(2);\
+			break;\
+		case 3:\
+			return _r_CORTEX_M_USART_##reg(3);\
+			break;\
+		case 4:\
+			return _r_CORTEX_M_USART_##reg(4);\
+			break;\
+		case 5:\
+			return _r_CORTEX_M_USART_##reg(5);\
+			break;\
+		case 6:\
+			return _r_CORTEX_M_USART_##reg(6);\
+			break;\
+		default:\
+			return NULL;\
+	}\
+}\
+
+USART_GET_REGISTER(SR)
+    USART_GET_REGISTER(DR)
+    USART_GET_REGISTER(BRR)
+    USART_GET_REGISTER(CR1)
+    USART_GET_REGISTER(CR2)
+    USART_GET_REGISTER(CR3)
+    USART_GET_REGISTER(GTPR)
+#endif/*!SOC_USART_REGS_H */

--- a/src/arch/socs/stm32f439/soc-usart.c
+++ b/src/arch/socs/stm32f439/soc-usart.c
@@ -1,24 +1,35 @@
-/* \file soc-usart.c
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #include "autoconf.h"
 #include "debug.h"

--- a/src/arch/socs/stm32f439/soc-usart.c
+++ b/src/arch/socs/stm32f439/soc-usart.c
@@ -1,0 +1,417 @@
+/* \file soc-usart.c
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#include "autoconf.h"
+#include "debug.h"
+#include "soc-gpio.h"
+#include "soc-nvic.h"
+#include "soc-rcc.h"
+#include "soc-interrupts.h"
+#include "soc-usart.h"
+#include "soc-usart-regs.h"
+
+/**** USART basic Read / Write ****/
+void soc_usart_putc(uint8_t usart, char c)
+{
+    /* Wait for TX to be ready */
+    while (!get_reg(r_CORTEX_M_USART_SR(usart), USART_SR_TXE))
+        continue;
+    *r_CORTEX_M_USART_DR(usart) = c;
+}
+
+/* Instantiate the putc for each USART */
+#define USART_PUTC_CALLBACK(num)\
+void soc_usart##num##_putc(char c)\
+{\
+	soc_usart_putc(num, c);\
+}\
+
+USART_PUTC_CALLBACK(1)
+USART_PUTC_CALLBACK(2)
+USART_PUTC_CALLBACK(3)
+USART_PUTC_CALLBACK(4)
+USART_PUTC_CALLBACK(5)
+USART_PUTC_CALLBACK(6)
+
+void soc_usart_write(uint8_t usart, char *msg, uint32_t len)
+{
+    while (len--) {
+        soc_usart_putc(usart, *msg);
+        msg++;
+    }
+}
+
+char soc_usart_getc(uint8_t usart)
+{
+    while (!get_reg(r_CORTEX_M_USART_SR(usart), USART_SR_RXNE))
+        continue;
+    return *r_CORTEX_M_USART_DR(usart);
+}
+
+/* Instantiate the getc for each USART */
+#define USART_GETC_CALLBACK(num)\
+char soc_usart##num##_getc(void)\
+{\
+	return soc_usart_getc(num);\
+}\
+
+USART_GETC_CALLBACK(1)
+    USART_GETC_CALLBACK(2)
+    USART_GETC_CALLBACK(3)
+    USART_GETC_CALLBACK(4)
+    USART_GETC_CALLBACK(5)
+    USART_GETC_CALLBACK(6)
+
+uint32_t soc_usart_read(uint8_t usart, char *buf, uint32_t len)
+{
+    uint32_t start_len = len;
+    while (len--) {
+        *buf = soc_usart_getc(usart);
+        if (*buf == '\n')
+            break;
+        buf++;
+    }
+    return start_len - len;
+}
+
+void soc_usart_set_baudrate(usart_config_t * config)
+{
+    uint32_t divider = 0;
+    uint16_t mantissa = 0;
+    uint8_t fraction = 0;
+
+    /* FIXME we should check CR1 in order to get the OVER8 configuration */
+
+    /* Compute the divider using the baudrate and the APB bus clock
+     * (APB1 or APB2) depending on the considered USART */
+    divider = soc_usart_get_bus_clock(config) / config->baudrate;
+
+    mantissa = (uint16_t) divider / 16;
+    fraction = (uint8_t) ((divider - mantissa * 16));
+    write_reg_value(r_CORTEX_M_USART_BRR(config->usart),
+                    (((mantissa & 0x0fff) << 4) | (0x0f & fraction)));
+}
+
+/* USART mapping for UART mode (TX, RX), and their configuration */
+#define UART_GPIO_COMMON(po, pi, x) \
+	{\
+	 .kref.port = po,\
+	 .kref.pin = pi,\
+	 .mask = GPIO_MASK_SET_MODE | GPIO_MASK_SET_PUPD | GPIO_MASK_SET_SPEED | GPIO_MASK_SET_TYPE | GPIO_MASK_SET_AFR,\
+	 .mode = GPIO_PIN_ALTERNATE_MODE,\
+	 .pupd = GPIO_NOPULL,\
+	 .speed = GPIO_PIN_VERY_HIGH_SPEED,\
+	 .type = GPIO_PIN_OTYPER_PP,\
+	 .afr = x,\
+	}\
+
+
+dev_gpio_info_t uart_gpio_config[] = {
+    /***************************************/
+    /* USART1 */
+    /* TX is PB6 with alternate function AF7 */
+    UART_GPIO_COMMON(GPIO_PB, 6, GPIO_AF_USART1),
+    /* RX is PB7 with alternate function AF7 */
+    UART_GPIO_COMMON(GPIO_PB, 7, GPIO_AF_USART1),
+    /***************************************/
+    /* USART2 */
+    /* TX is PA2 with alternate function AF7 */
+    UART_GPIO_COMMON(GPIO_PA, 2, GPIO_AF_USART2),
+    /* RX is PA3 with alternate function AF7 */
+    UART_GPIO_COMMON(GPIO_PA, 3, GPIO_AF_USART2),
+    /***************************************/
+    /* USART3 */
+    /* TX is PB10 with alternate function AF7 */
+    UART_GPIO_COMMON(GPIO_PB, 10, GPIO_AF_USART3),
+    /* RX is PB11 with alternate function AF7 */
+    UART_GPIO_COMMON(GPIO_PB, 11, GPIO_AF_USART3),
+    /***************************************/
+    /* USART4 */
+#ifdef CONFIG_WOOKEY
+    UART_GPIO_COMMON(GPIO_PA, 0, GPIO_AF_USART4),
+    UART_GPIO_COMMON(GPIO_PA, 1, GPIO_AF_USART4),
+#elif CONFIG_DISCO407
+    /* TX is PC10 with alternate function AF8 */
+    UART_GPIO_COMMON(GPIO_PC, 10, GPIO_AF_USART4),
+    /* RX is PC11 with alternate function AF8 */
+    UART_GPIO_COMMON(GPIO_PC, 11, GPIO_AF_USART4),
+#elif CONFIG_DISCO429
+    /* TX is PC10 with alternate function AF8 */
+    UART_GPIO_COMMON(GPIO_PC, 10, GPIO_AF_USART4),
+    /* RX is PC11 with alternate function AF8 */
+    UART_GPIO_COMMON(GPIO_PC, 11, GPIO_AF_USART4),
+#else
+# error "STM32F4xx-based board not supported, check GPIO config"
+#endif
+    /***************************************/
+    /* USART5 */
+    /* TX is PC12 with alternate function AF8 */
+    UART_GPIO_COMMON(GPIO_PC, 12, GPIO_AF_USART5),
+    /* RX is PD2 with alternate function AF8 */
+    UART_GPIO_COMMON(GPIO_PD, 2, GPIO_AF_USART5),
+    /***************************************/
+    /* USART6 */
+    /* TX is PC6 with alternate function AF8 */
+    UART_GPIO_COMMON(GPIO_PC, 6, GPIO_AF_USART6),
+    /* RX is PC7 with alternate function AF8 */
+    UART_GPIO_COMMON(GPIO_PC, 7, GPIO_AF_USART6),
+};
+
+/* This is a template configuration for the USART in UART mode */
+
+/* FIXME should be rewritten in order to handle all uart configurations
+ * [RB]: first attempt to implement this ...
+ */
+static void soc_usart_init_gpio(usart_config_t * config)
+{
+    dev_gpio_info_t *tx_config;
+    dev_gpio_info_t *rx_config;
+
+    /* Sanity check */
+    if ((config->usart < 1) || (config->usart > 6)) {
+        panic("Wrong usart %d. You should use USART1 to USART6", config->usart);
+    }
+
+    switch (config->mode) {
+    case UART:
+        tx_config = &uart_gpio_config[2 * (config->usart - 1)];
+        rx_config = &uart_gpio_config[(2 * (config->usart - 1)) + 1];
+
+        if (tx_config->kref.port == 0 && rx_config->kref.port == 0) {
+            panic
+                ("UART usart %d does not seem to support UART or to be rooted on the board!",
+                 config->usart);
+        }
+
+        soc_gpio_configure
+           (tx_config->kref.port,
+            tx_config->kref.pin,
+            tx_config->mode,
+            tx_config->type,
+            tx_config->speed,
+            tx_config->pupd,
+            tx_config->afr);
+
+        soc_gpio_configure
+           (rx_config->kref.port,
+            rx_config->kref.pin,
+            rx_config->mode,
+            rx_config->type,
+            rx_config->speed,
+            rx_config->pupd,
+            rx_config->afr);
+
+        break;
+    default:
+        panic("Wrong usart mode %d.", config->mode);
+    }
+}
+
+static void soc_usart_clock_init(usart_config_t * config)
+{
+    switch (config->usart) {
+    case 1:
+        set_reg_bits(r_CORTEX_M_RCC_APB2ENR, RCC_APB2ENR_USART1EN);
+        break;
+    case 2:
+        set_reg_bits(r_CORTEX_M_RCC_APB1ENR, RCC_APB1ENR_USART2EN);
+        break;
+    case 3:
+        set_reg_bits(r_CORTEX_M_RCC_APB1ENR, RCC_APB1ENR_USART3EN);
+        break;
+    case 4:
+        set_reg_bits(r_CORTEX_M_RCC_APB1ENR, RCC_APB1ENR_UART4EN);
+        break;
+    case 5:
+        set_reg_bits(r_CORTEX_M_RCC_APB1ENR, RCC_APB1ENR_UART5EN);
+        break;
+    case 6:
+        set_reg_bits(r_CORTEX_M_RCC_APB2ENR, RCC_APB2ENR_USART6EN);
+        break;
+    default:
+        panic("Wrong usart %d. You should use USART1 to USART6", config->usart);
+    }
+
+    return;
+}
+
+/**** IRQ Handlers ****/
+
+#define USART_IRQHANDLER(num, type) \
+/* Global variable holding the callback to USART num */\
+cb_usart_data_received_t cb_usart##num##_data_received = NULL;\
+/* Register the IRQ */\
+void U##type##ART##num##_IRQ_Handler(stack_frame_t *sf __attribute__((unused)))\
+{\
+	if(cb_usart##num##_data_received != NULL){\
+		cb_usart##num##_data_received();\
+	}\
+}
+
+/*
+ * Instantiate the IRQs for the 6 USARTs
+ * Note: The 2nd macro argument handles the fact that USART 4 and 5 are in
+ * UARTs.
+ */
+USART_IRQHANDLER(1, S)
+    USART_IRQHANDLER(2, S)
+    USART_IRQHANDLER(3, S)
+    USART_IRQHANDLER(4,)
+    USART_IRQHANDLER(5,)
+    USART_IRQHANDLER(6, S)
+
+/* Configure the handlers */
+#define USART_CONFIG_CALLBACKS(num, type) \
+	case num:\
+		if (config->callback_data_received != NULL){\
+			NVIC_EnableIRQ(U##type##ART##num##_IRQ - 0x10);\
+			/* Enable dedicated IRQ and register the callback */\
+			cb_usart##num##_data_received = config->callback_data_received;\
+		}\
+		if(config->callback_usart_getc_ptr != NULL){\
+			*(config->callback_usart_getc_ptr) = soc_usart##num##_getc;\
+		}\
+		if(config->callback_usart_putc_ptr != NULL){\
+			*(config->callback_usart_putc_ptr) = soc_usart##num##_putc;\
+		}\
+		break;\
+
+static void soc_usart_callbacks_init(usart_config_t * config)
+{
+    if (config->callback_data_received) {
+        /* A reception callback has been provided: enable interrupts
+         * for RX using the control register
+         */
+        set_reg_bits(r_CORTEX_M_USART_CR1(config->usart), USART_CR1_RXNEIE_Msk);
+    }
+    switch (config->usart) {
+        USART_CONFIG_CALLBACKS(1, S)
+        USART_CONFIG_CALLBACKS(2, S)
+        USART_CONFIG_CALLBACKS(3, S)
+        USART_CONFIG_CALLBACKS(4,)
+        USART_CONFIG_CALLBACKS(5,)
+        USART_CONFIG_CALLBACKS(6, S)
+    default:
+        panic("Wrong usart %d. You should use USART1 to USART6", config->usart);
+    }
+
+    return;
+}
+
+/**** usart_init ****/
+void soc_usart_init(usart_config_t * config)
+{
+
+    soc_usart_clock_init(config);
+    soc_usart_init_gpio(config);
+    soc_usart_set_baudrate(config);
+
+    /* registering the handler */
+    /*
+    switch (config->usart) {
+      case 0:
+      case 1:
+        irq_handler_set(USART1_IRQ, USART1_IRQ_Handler, 0, ID_DEV_UNUSED);
+        break;
+      case 2:
+        irq_handler_set(USART2_IRQ, USART2_IRQ_Handler, 0, ID_DEV_UNUSED);
+        break;
+      case 3:
+        irq_handler_set(USART3_IRQ, USART3_IRQ_Handler, 0, ID_DEV_UNUSED);
+        break;
+      case 4:
+        irq_handler_set(UART4_IRQ, UART4_IRQ_Handler, 0, ID_DEV_UNUSED);
+        break;
+      case 5:
+        irq_handler_set(UART5_IRQ, UART5_IRQ_Handler, 0, ID_DEV_UNUSED);
+        break;
+      case 6:
+        irq_handler_set(USART6_IRQ, USART6_IRQ_Handler, 0, ID_DEV_UNUSED);
+        break;
+      default:
+        irq_handler_set(USART1_IRQ, USART1_IRQ_Handler, 0, ID_DEV_UNUSED);
+    }
+    */
+
+    /* Control register 1 */
+    set_reg(r_CORTEX_M_USART_CR1(config->usart), config->parity,
+            USART_CONFIG_PARITY);
+    set_reg(r_CORTEX_M_USART_CR1(config->usart), config->options_cr1,
+            USART_CONFIG_OPTIONS_CR1);
+
+    /* Control register 2 */
+    set_reg(r_CORTEX_M_USART_CR2(config->usart), config->stop_bits,
+            USART_CONFIG_STOP_BITS);
+    set_reg(r_CORTEX_M_USART_CR1(config->usart), config->options_cr2,
+            USART_CONFIG_OPTIONS_CR2);
+
+    /* USART 4 and 5 have some configuration limitations: check them before continuing */
+    if ((config->hw_flow_control & (USART_CR3_CTSIE_Msk | USART_CR3_CTSE_Msk |
+                                    USART_CR3_RTSE_Msk | USART_CR3_SCEN_Msk |
+                                    USART_CR3_NACK_Msk))
+        && ((config->usart == 4) || (config->usart == 5))) {
+        panic
+            ("Usart%d config error: asking for a flag in CR3 unavailable for USART4 and USART5",
+             config->usart);
+    }
+    if ((config->hw_flow_control & (USART_CR3_DMAT_Msk | USART_CR3_DMAR_Msk))
+        && (config->usart == 5)) {
+        panic
+            ("Usart%d config error: asking for a flag in CR3 unavailable for USART5",
+             config->usart);
+    }
+    if ((config->guard_time_prescaler)
+        && ((config->usart == 4) || (config->usart == 5))) {
+        panic
+            ("Usart%d config error: asking for guard time/prescaler in GTPR unavailable for USART4 and USART5",
+             config->usart);
+    }
+    /* Control register 3 */
+    set_reg(r_CORTEX_M_USART_CR3(config->usart), config->hw_flow_control,
+            USART_CONFIG_HW_FLW_CTRL);
+
+    /* Initialize callbacks */
+    soc_usart_callbacks_init(config);
+
+    return;
+}
+
+/* Get the current clock value of the USART bus */
+uint32_t soc_usart_get_bus_clock(usart_config_t * config)
+{
+    switch (config->usart) {
+    case 1:
+    case 6:
+        return PROD_CLOCK_APB2;
+        break;
+    case 2:
+    case 3:
+    case 4:
+    case 5:
+        return PROD_CLOCK_APB1;
+        break;
+    default:
+        panic("Wrong usart %d. You should use USART1 to USART6", config->usart);
+    }
+
+    return 0;
+}

--- a/src/arch/socs/stm32f439/soc-usart.h
+++ b/src/arch/socs/stm32f439/soc-usart.h
@@ -1,24 +1,35 @@
-/* \file soc-usart.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef SOC_USART_H
 #define SOC_USART_H

--- a/src/arch/socs/stm32f439/soc-usart.h
+++ b/src/arch/socs/stm32f439/soc-usart.h
@@ -1,0 +1,217 @@
+/* \file soc-usart.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef SOC_USART_H
+#define SOC_USART_H
+
+#include "types.h"
+#include "regutils.h"
+#include "soc-interrupts.h"
+#include "soc-usart-regs.h"
+#include "gpio.h"
+
+// TODO: differenciate tx_port and rx_port that may differs
+static const struct {
+  char *   name;
+  uint8_t  port;   /* GPIO_PA, GPIO_PB, ... */
+  uint8_t  tx_pin;
+  uint8_t  rx_pin;
+  uint8_t  sc_port;
+  uint8_t  sc_tx_pin;
+  uint8_t  sc_ck_pin;
+  uint8_t  irq;
+  uint8_t  af;
+} soc_usarts[] = {
+ { "",       0,    0,  0,   0,  0,  0, 53, 0x7 },
+ { "usart1", GPIO_PB,  6,  7, GPIO_PA,  9,  8, 53, 0x7 },
+ { "usart2", GPIO_PA,  2,  3, GPIO_PA,  2,  4, 54, 0x7 },
+ { "usart3", GPIO_PB, 10, 11, GPIO_PB, 10, 12, 55, 0x7 },
+ { "uart4",  GPIO_PA,  0,  1,   0,  0,  0, 68, 0x8 },
+ { "uart5",  GPIO_PC, 12,  2,   0,  0,  0, 69, 0x8 },
+ { "usart6", GPIO_PC,  6,  7, GPIO_PC,  6,  8, 89, 0x8 }
+};
+
+
+typedef void (*cb_usart_data_received_t) (void);
+typedef char (*cb_usart_getc_t) (void);
+typedef void (*cb_usart_putc_t) (char);
+
+/* Defines the USART mode that we consider
+ * [RB] TODO: to be completed with other USART modes if/when needed! (IrDA, LIN, ...)
+ * For now, only the classical UART console mode and the SMARTCARD modes are
+ * implemented.
+ */
+typedef enum { UART, SMARTCARD, CUSTOM } usart_mode;
+
+/* [RB] TODO: add some magic initialization values and assert to avoid manipulation
+ * of uninitialized structures!
+ */
+typedef struct __packed {
+
+    uint8_t usart;
+    usart_mode mode;
+    uint32_t baudrate;          /* USART_BRR:DIV_Mantissa[11:0]: and DIV_Fraction[3:0]: */
+    uint32_t word_length;       /* USART_CR1:Bit 12 M: Word length */
+    uint32_t parity;            /* USART_CR1:Bit 9 PS: Parity selection and Bit 10 PCE: Parity control enable */
+    uint32_t stop_bits;         /* USART_CR2:Bits 13:12 STOP: STOP bits,  */
+    uint32_t hw_flow_control;   /* USART_CR3:
+                                   Bit 11 ONEBIT: One sample bit method enable
+                                   Bit 10 CTSIE: CTS interrupt enable
+                                   Bit 9 CTSE: CTS enable
+                                   Bit 8 RTSE: RTS enable
+                                   Bit 7 DMAT: DMA enable transmitter
+                                   Bit 6 DMAR: DMA enable receiver
+                                   Bit 5 SCEN: Smartcard mode enable
+                                   Bit 4 NACK: Smartcard NACK enable
+                                   Bit 3 HDSEL: Half-duplex selection
+                                   Bit 2 IRLP: IrDA low-power
+                                   Bit 1 IREN: IrDA mode enable
+                                   Bit 0 EIE: Error interrupt enable */
+    /* Additional options in CR1 */
+    uint32_t options_cr1;       /* USART_CR1:
+                                   Bit 15 OVER8:
+                                   Bit 13 UE: USART enable
+                                   Bit 11 WAKE: Wakeup method
+                                   Bit 8 PEIE: PE interrupt enable
+                                   Bit 7 TXEIE: TXE interrupt enable
+                                   Bit 6 TCIE: Transmission complete interrupt enable
+                                   Bit 5 RXNEIE: RXNE interrupt enable
+                                   Bit 4 IDLEIE: IDLE interrupt enable
+                                   Bit 3 TE: Transmitter enable
+                                   Bit 2 RE: Receiver enable
+                                   Bit 1 RWU: Receiver wakeup
+                                   Bit 0 SBK: Send break */
+    /* Additional options in CR2 */
+    uint32_t options_cr2;       /* USART_CR2:
+                                   Bit 14 LINEN: LIN mode enable
+                                   Bit 11 CLKEN: Clock enable
+                                   Bit 10 CPOL: Clock polarity
+                                   Bit 9 CPHA: Clock phase
+                                   Bit 8 LBCL: Last bit clock pulse
+                                   Bit 6 LBDIE: LIN break detection interrupt enable
+                                   Bit 5 LBDL: lin break detection length */
+    uint32_t guard_time_prescaler;  /* USART_GTPR: (used for Smartcard and IrDA modes
+                                     * Bits 15:8 GT[7:0]: Guard time value
+                                     * Bits 7:0 PSC[7:0]: Prescaler value */
+    cb_usart_data_received_t callback_data_received;
+    cb_usart_getc_t *callback_usart_getc_ptr;
+    cb_usart_putc_t *callback_usart_putc_ptr;
+} usart_config_t;
+
+#define USART_CONFIG_WORD_LENGTH_BITS_Msk (define USART_CR1_M_Msk)
+#define USART_CONFIG_WORD_LENGTH_BITS_Pos 0
+
+#define USART_CONFIG_PARITY_Msk (USART_CR1_PS_Msk | USART_CR1_PCE_Msk)
+#define USART_CONFIG_PARITY_Pos 0
+
+#define USART_CONFIG_STOP_BITS_Msk (USART_CR2_STOP_Msk)
+#define USART_CONFIG_STOP_BITS_Pos 0
+
+#define USART_CONFIG_OPTIONS_CR1_Msk (USART_CR1_OVER8_Msk \
+                                | USART_CR1_UE_Msk \
+                                | USART_CR1_WAKE_Msk \
+                                | USART_CR1_PEIE_Msk \
+                                | USART_CR1_TXEIE_Msk \
+                                | USART_CR1_TCIE_Msk \
+                                | USART_CR1_RXNEIE_Msk \
+                                | USART_CR1_IDLEIE_Msk \
+                                | USART_CR1_TE_Msk \
+                                | USART_CR1_RE_Msk \
+                                | USART_CR1_RWU_Msk \
+                                | USART_CR1_SBK_Msk )
+#define USART_CONFIG_OPTIONS_CR1_Pos 0
+
+#define USART_CONFIG_OPTIONS_CR2_Msk ( USART_CR2_LINEN_Msk \
+				| USART_CR2_CLKEN_Msk \
+				| USART_CR2_CPOL_Msk \
+				| USART_CR2_CPHA_Msk \
+				| USART_CR2_LBCL_Msk \
+				| USART_CR2_LBDIE_Msk \
+				| USART_CR2_LBDL_Msk )
+#define USART_CONFIG_OPTIONS_CR2_Pos 0
+
+#define USART_CONFIG_HW_FLW_CTRL_Msk (USART_CR3_ONEBIT_Msk \
+                                    | USART_CR3_CTSIE_Msk \
+                                    | USART_CR3_CTSE_Msk \
+                                    | USART_CR3_RTSE_Msk \
+                                    | USART_CR3_DMAT_Msk \
+                                    | USART_CR3_DMAR_Msk \
+                                    | USART_CR3_SCEN_Msk \
+                                    | USART_CR3_NACK_Msk \
+                                    | USART_CR3_HDSEL_Msk \
+                                    | USART_CR3_IRLP_Msk \
+                                    | USART_CR3_IREN_Msk \
+                                    | USART_CR3_EIE_Msk )
+#define USART_CONFIG_HW_FLW_CTRL_Pos    0
+
+#define USART_CONFIG_GUARD_TIME_PRESCALER_Msk (USART_GTPR_GT_Msk | USART_GTPR_PSC_Msk)
+#define USART_CONFIG_GUARD_TIME_PRESCALER_Pos	0
+
+/**
+ * usart_init - Initialize the USART
+ * @n: USART to use (1 or 4).
+ * @callback_data_received: function called when data is received on the RX
+ * pin. If this argument is NULL, USART IRQs are disabled.
+ *
+ * This function initialize USART1 (n = 1) or UART4 (n = 4) as 8N1 at a
+ * baudrate of 115200
+ */
+void soc_usart_init(usart_config_t * config);
+
+/**
+ * usart_putc - Send a character
+ * @c: Character to send.
+ */
+void soc_usart_putc(uint8_t usart, char c);
+
+/**
+ * usart_write - Send a string
+ * @msg: string of size @len to send.
+ * @len: size of @msg.
+ */
+void soc_usart_write(uint8_t usart, char *msg, uint32_t len);
+
+/**
+ * usart_getc - Read a character
+ * Return: The character read.
+ */
+char soc_usart_getc(uint8_t usart);
+
+/**
+ * usart_read - Read a string
+ * @buf: Address of the buffer in which the read characters will be written.
+ * The size of the buffer must be at least @len.
+ * @len: Number of characters to read.
+ */
+uint32_t soc_usart_read(uint8_t usart, char *buf, uint32_t len);
+
+/* Get the clock frequency value of the APB bus driving the USART */
+uint32_t soc_usart_get_bus_clock(usart_config_t * config);
+
+void USART1_IRQ_Handler(stack_frame_t *sf);
+void USART2_IRQ_Handler(stack_frame_t *sf);
+void USART3_IRQ_Handler(stack_frame_t *sf);
+void UART4_IRQ_Handler(stack_frame_t *sf);
+void UART5_IRQ_Handler(stack_frame_t *sf);
+void USART6_IRQ_Handler(stack_frame_t *sf);
+
+#endif/*!SOC_USART_H */

--- a/src/arch/socs/stm32f439/startup_stm32f439.s
+++ b/src/arch/socs/stm32f439/startup_stm32f439.s
@@ -1,0 +1,329 @@
+/**
+  ******************************************************************************
+  * @file      startup_stm32f4xx.s
+  * @author    MCD Application Team
+  * @version   V1.0.0
+  * @date      30-September-2011
+  * @brief     STM32F4xx Devices vector table for Atollic TrueSTUDIO toolchain.
+  *            This module performs:
+  *                - Set the initial SP
+  *                - Set the initial PC == Reset_Handler,
+  *                - Set the vector table entries with the exceptions ISR address
+  *                - Configure the clock system and the external SRAM mounted on
+  *                  STM324xG-EVAL board to be used as data memory (optional,
+  *                  to be enabled by user)
+  *                - Branches to main in the C library (which eventually
+  *                  calls main()).
+  *            After Reset the Cortex-M4 processor is in Thread mode,
+  *            priority is Privileged, and the Stack is set to Main.
+  ******************************************************************************
+  * @attention
+  *
+  * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+  * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+  * TIME. AS A RESULT, STMICROELECTRONICS SHALL NOT BE HELD LIABLE FOR ANY
+  * DIRECT, INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+  * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+  * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+  *
+  * <h2><center>&copy; COPYRIGHT 2011 STMicroelectronics</center></h2>
+  ******************************************************************************
+  */
+
+.syntax unified
+.cpu cortex-m4
+.fpu softvfp
+.thumb
+
+.global g_pfnVectors
+.global g_BaseAddress
+.global g_StackAddress
+
+.extern Default_SubHandler
+
+/* start address for the initialization values of the .data section. defined in linker script */
+.word   _sidata
+/* start address for the .data section. defined in linker script */
+.word   _sdata
+/* end address for the .data section. defined in linker script */
+.word   _edata
+/* start address for the .bss section. defined in linker script */
+.word   _sbss
+/* end address for the .bss section. defined in linker script */
+.word   _ebss
+.word   _sigot
+.word   _sgot
+.word   _egot
+
+
+/*
+.word   _svtors
+.word   _evtors
+*/
+/*
+ * @brief Globals variables
+ * @param  None
+ * @retval None
+ *
+ */
+
+.section .data
+g_BaseAddress:
+    .word 0
+g_StackAddress:
+    .word 0
+
+/*
+ * @brief  This is the code that gets called when the processor first
+ *          starts execution following a reset event. Only the absolutely
+ *          necessary set is performed, after which the application
+ *          supplied main() routine is called.
+ * @param  None
+ * @retval None
+ */
+
+.section .text.Reset_Handler
+    .weak  Reset_Handler
+    .type  Reset_Handler, %function
+Reset_Handler:
+    bl  _start                  /* Entry point address */
+_start:
+    movs    r5, lr
+    sub     r5, #5              /* In thumb mode LR is pointing to PC + 4 bytes  + 1 because in thumb mode LR must be odd aligned*/
+    sub     r2, r5, #0x188      /* Compute vector table address FIXME: We should use dynimic value for VTORS_SIZE */
+    ldr     r2, [r2]
+    msr     msp, r2             /* Reset stack address to default 0x20002000 */
+
+    movs  r1, #0
+    b       LoopCopyDataInit
+CopyDataInit:                   /* Copy the data segment initializers from flash to SRAM */
+    ldr     r3, =_sidata        /* start address for the initialization values of the .data section. */
+    ldr     r3, [r3, r1]
+    str     r3, [r0, r1]
+    adds    r1, r1, #4
+LoopCopyDataInit:
+    ldr     r0, =_sdata         /* start address for the .data section */
+    ldr     r3, =_edata         /* end address for the .data section */
+    adds    r2, r0, r1
+    cmp     r2, r3
+    bcc     CopyDataInit
+
+
+    ldr     r2, =_sbss          /* start address for the .bss section */
+    b       LoopFillZerobss
+FillZerobss:                     /* Zero fill the bss segment. */
+    movs    r3, #0
+    str     r3, [r2], #4
+LoopFillZerobss:
+    ldr     r3, = _ebss          /* end address for the .bss section */
+    cmp     r2, r3
+    bcc     FillZerobss
+    movs    r0, #1
+    ldr     r1, = g_BaseAddress
+    str     r5, [r1]
+    dmb
+    bl      main
+    bx      lr
+
+.size  Reset_Handler, .-Reset_Handler
+
+.section .text.Default_Handler
+    .weak  Default_Handler
+    .type  Default_Handler, %function
+Default_Handler:
+    cpsid   i
+
+    /*
+     * The NVIC has already saved R0-R3, R12, LR, PC and xPSR registers on the
+     * stack. We save the remaining registers (R4-R11) and LR (with the new
+     * value) on that previously used stack.
+     */
+
+    /* 1) Which stack was previously used ?  */
+
+    tst     lr, #4      /* bit 2: (0) MSP (1) PSP stack      */
+    ite     eq          /* if equal 0                        */
+    mrseq   r0, msp     /* r0 <- MSP                         */
+    mrsne   r0, psp     /* r0 <- PSP (process stack)         */
+
+    /*
+     * 2) Save registers on the previously used stack.
+     *    R0 points to the saved registers:
+     *        LR, R4-R11, R0-R3, R12, previous LR, PC, xPSR
+     */
+
+    stmfd   r0!, {r4-r11, lr}
+
+    /* 3) Adjusting the previously used stack pointer (might be PSP or MSP) */
+
+    tst     lr, #4      /* bit 2: (0) MSP (1) PSP stack      */
+    ite     eq          /* if equal 0                        */
+    msreq   msp, r0     /* MSP <- r0                         */
+    msrne   psp, r0     /* PSP <- r0                         */
+
+    /*
+     * R0 is passed as a parameter. It still points to the saved registers.
+     * In case of task switching, R0 returned by `Default_SubHandler' might be
+     * different.
+     * R1 is returned by `Default_SubHandler' and it contains the task type.
+     * Valid R1 values are privileged (0) or unprivileged (1).
+     */
+
+    bl      Default_SubHandler
+
+    /* Registers LR, R4-R11 are restored */
+    ldmfd   r0!, {r4-r11, lr}
+
+    /*
+     * Adjusting PSP/MSP so that the NVIC can restore the remaining registers
+     * and setting the execution mode (privileged or unprivileged)
+     */
+
+    tst     lr, #4      /* bit 2: (0) MSP (1) PSP stack      */
+    bne     psp_use     /* if not equal 0                    */
+
+msp_use:
+    /* That branch should never be executed as every task use the PSP */
+    msr     msp, r0     /* MSP <- r0 */
+    cpsie   i
+    bx      lr
+
+psp_use:
+    msr     psp, r0     /* PSP <- r0 */
+
+    /* Is it an unprivileged task ? */
+    cmp     r1, #1
+    bne     kern_mode
+
+user_mode:
+    mov     r0, #3
+    msr     control, r0
+    isb
+    cpsie   i
+    bx      lr
+
+kern_mode:
+    mov     r0, #2
+    msr     control, r0
+    isb
+    cpsie   i
+    bx      lr
+.size Default_Handler, .-Default_Handler
+
+/******************************************************************************
+ *
+ * The minimal vector table for a Cortex M4. Note that the proper constructs
+ * must be placed on this to ensure that it ends up at physical address
+ * 0x0000.0000.
+ *
+ ******************************************************************************/
+.section  .isr_vector,"a",%progbits
+  .type  g_pfnVectors, %object
+  .size  g_pfnVectors, .-g_pfnVectors
+
+g_pfnVectors:
+  .word  _estack
+  .word  Reset_Handler
+  .word  Default_Handler
+  .word  Default_Handler
+  .word  Default_Handler
+  .word  Default_Handler
+  .word  Default_Handler
+  .word  0
+  .word  0
+  .word  0
+  .word  0
+  .word  Default_Handler
+  .word  Default_Handler
+  .word  0
+  .word  Default_Handler
+  .word  Default_Handler
+
+  /*
+   * External Interrupts
+   */
+  .word     Default_Handler     /* Window WatchDog */
+  .word     Default_Handler     /* PVD through EXTI Line detection */
+  .word     Default_Handler     /* Tamper and TimeStamps through the EXTI line */
+  .word     Default_Handler     /* RTC Wakeup through the EXTI line */
+  .word     Default_Handler     /* FLASH */
+  .word     Default_Handler     /* RCC */
+  .word     Default_Handler     /* EXTI Line0 */
+  .word     Default_Handler     /* EXTI Line1 */
+  .word     Default_Handler     /* EXTI Line2 */
+  .word     Default_Handler     /* EXTI Line3 */
+  .word     Default_Handler     /* EXTI Line4 */
+  .word     Default_Handler     /* DMA1 Stream 0 */
+  .word     Default_Handler     /* DMA1 Stream 1 */
+  .word     Default_Handler     /* DMA1 Stream 2 */
+  .word     Default_Handler     /* DMA1 Stream 3 */
+  .word     Default_Handler     /* DMA1 Stream 4 */
+  .word     Default_Handler     /* DMA1 Stream 5 */
+  .word     Default_Handler     /* DMA1 Stream 6 */
+  .word     Default_Handler     /* ADC1, ADC2 and ADC3s */
+  .word     Default_Handler     /* CAN1 TX */
+  .word     Default_Handler     /* CAN1 RX0 */
+  .word     Default_Handler     /* CAN1 RX1 */
+  .word     Default_Handler     /* CAN1 SCE */
+  .word     Default_Handler     /* External Line[9:5]s */
+  .word     Default_Handler     /* TIM1 Break and TIM9 */
+  .word     Default_Handler     /* TIM1 Update and TIM10 */
+  .word     Default_Handler     /* TIM1 Trigger and Commutation and TIM11 */
+  .word     Default_Handler     /* TIM1 Capture Compare */
+  .word     Default_Handler     /* TIM2 */
+  .word     Default_Handler     /* TIM3 */
+  .word     Default_Handler     /* TIM4 */
+  .word     Default_Handler     /* I2C1 Event */
+  .word     Default_Handler     /* I2C1 Error */
+  .word     Default_Handler     /* I2C2 Event */
+  .word     Default_Handler     /* I2C2 Error */
+  .word     Default_Handler     /* SPI1 */
+  .word     Default_Handler     /* SPI2 */
+  .word     Default_Handler     /* USART1 */
+  .word     Default_Handler     /* USART2 */
+  .word     Default_Handler     /* USART3 */
+  .word     Default_Handler     /* External Line[15:10]s */
+  .word     Default_Handler     /* RTC Alarm (A and B) through EXTI Line */
+  .word     Default_Handler     /* USB OTG FS Wakeup through EXTI line */
+  .word     Default_Handler     /* TIM8 Break and TIM12 */
+  .word     Default_Handler     /* TIM8 Update and TIM13 */
+  .word     Default_Handler     /* TIM8 Trigger and Commutation and TIM14 */
+  .word     Default_Handler     /* TIM8 Capture Compare */
+  .word     Default_Handler     /* DMA1 Stream7 */
+  .word     Default_Handler     /* FSMC */
+  .word     Default_Handler     /* SDIO */
+  .word     Default_Handler     /* TIM5 */
+  .word     Default_Handler     /* SPI3 */
+  .word     Default_Handler     /* UART4 */
+  .word     Default_Handler     /* UART5 */
+  .word     Default_Handler     /* TIM6 and DAC1&2 underrun errors */
+  .word     Default_Handler     /* TIM7 */
+  .word     Default_Handler     /* DMA2 Stream 0 */
+  .word     Default_Handler     /* DMA2 Stream 1 */
+  .word     Default_Handler     /* DMA2 Stream 2 */
+  .word     Default_Handler     /* DMA2 Stream 3 */
+  .word     Default_Handler     /* DMA2 Stream 4 */
+  .word     Default_Handler     /* Ethernet */
+  .word     Default_Handler     /* Ethernet Wakeup through EXTI line */
+  .word     Default_Handler     /* CAN2 TX */
+  .word     Default_Handler     /* CAN2 RX0 */
+  .word     Default_Handler     /* CAN2 RX1 */
+  .word     Default_Handler     /* CAN2 SCE */
+  .word     Default_Handler     /* USB OTG FS */
+  .word     Default_Handler     /* DMA2 Stream 5 */
+  .word     Default_Handler     /* DMA2 Stream 6 */
+  .word     Default_Handler     /* DMA2 Stream 7 */
+  .word     Default_Handler     /* USART6 */
+  .word     Default_Handler     /* I2C3 event */
+  .word     Default_Handler     /* I2C3 error */
+  .word     Default_Handler     /* USB OTG HS End Point 1 Out */
+  .word     Default_Handler     /* USB OTG HS End Point 1 In */
+  .word     Default_Handler     /* USB OTG HS Wakeup through EXTI */
+  .word     Default_Handler     /* USB OTG HS */
+  .word     Default_Handler     /* DCMI */
+  .word     Default_Handler     /* CRYP crypto */
+  .word     Default_Handler     /* Hash and Rng */
+  .word     Default_Handler     /* FPU */
+
+
+/*******************   (C)   COPYRIGHT   2011   STMicroelectronics   *****END   OF   FILE****/

--- a/src/crc32.c
+++ b/src/crc32.c
@@ -1,24 +1,35 @@
-/* \file fw_crc32.c
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #include "crc32.h"
 

--- a/src/crc32.h
+++ b/src/crc32.h
@@ -1,24 +1,35 @@
-/* \file fw_crc32.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef CRC32_H_
 #define CRC32_H_

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,0 +1,619 @@
+/* \file debug.c
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#include "stdarg.h"
+
+#include "autoconf.h"
+#include "debug.h"
+#include "libc.h"
+#include "soc-init.h"
+#include "soc-usart.h"
+
+#define BUF_MAX		512
+
+#ifndef CONFIG_KERNEL_NOSERIAL
+volatile int logging = CONFIG_KERNEL_CONSOLE_TXT;
+#endif
+
+cb_usart_getc_t console_getc = NULL;
+cb_usart_putc_t console_putc = NULL;
+
+static struct {
+    uint32_t start;
+    uint32_t end;
+    bool     full;
+    char buf[BUF_MAX];
+} ring_buffer;
+
+void init_ring_buffer(void)
+{
+    /* init flags */
+    int     i = 0;
+
+    ring_buffer.end = 0;
+    ring_buffer.start = ring_buffer.end;
+    ring_buffer.full = false;
+
+    /* memsetting buffer
+     * NOTE: This may be useless as, in EwoK, the BSS is zeroified
+     * at boot time.
+     */
+    for (i = 0; i < BUF_MAX; i++) {
+        ring_buffer.buf[i] = '\0';
+    }
+}
+
+#ifndef CONFIG_KERNEL_NOSERIAL
+void cb_console_data_received(void)
+{
+    char c;
+    if (console_getc == NULL) {
+        panic("Error: console_getc not initialized!");
+    }
+
+    c = console_getc();
+
+
+    if (logging && console_putc) {
+        if (c == '\r') {
+          console_putc('\r');
+          console_putc('\n');
+        } else {
+          console_putc(c);
+        }
+    }
+}
+
+static usart_config_t console_config = { 0 };
+#endif
+
+void debug_console_init(void)
+{
+    /* init ring buffer. The ring buffer is keeped to support sys_ipc(LOG) syscalls,
+     * even when no serial is activated. The ring buffer is never flushed and the
+     * sys_ipc(LOG) syscall behave like writing in /dev/null.
+     */
+    init_ring_buffer();
+#ifndef CONFIG_KERNEL_NOSERIAL
+    /* Configure the USART in UART mode */
+    console_config.usart = CONFIG_KERNEL_USART;
+    console_config.baudrate = 115200;
+    console_config.word_length = USART_CR1_M_8;
+    console_config.stop_bits = USART_CR2_STOP_1BIT;
+    console_config.parity = USART_CR1_PCE_DIS;
+    console_config.hw_flow_control = USART_CR3_CTSE_CTS_DIS | USART_CR3_RTSE_RTS_DIS;
+    console_config.options_cr1 = USART_CR1_TE_EN | USART_CR1_RE_EN | USART_CR1_UE_EN;
+    console_config.callback_data_received = cb_console_data_received;
+    console_config.callback_usart_getc_ptr = &console_getc;
+    console_config.callback_usart_putc_ptr = &console_putc;
+
+    /* Initialize the USART related to the console */
+    soc_usart_init(&console_config);
+    dbg_log("[USART%d initialized for console output, baudrate=%d]\n",
+            console_config.usart, console_config.baudrate);
+    dbg_flush();
+#endif
+}
+
+static void ring_buffer_reset(void)
+{
+    ring_buffer.end = 0;
+    ring_buffer.start = ring_buffer.end;
+    ring_buffer.full = false;
+
+    memset(ring_buffer.buf, 0x0, BUF_MAX);
+}
+
+static inline void ring_buffer_write_char(const char c)
+{
+    /* if the ring buffer is full when we try to put char in it,
+     * the car is discared, waiting for the ring buffer to be flushed.
+     */
+    if (ring_buffer.full) {
+        goto end;
+    }
+    ring_buffer.buf[ring_buffer.end] = c;
+    if (((ring_buffer.end + 1) % BUF_MAX) != ring_buffer.start) {
+        ring_buffer.end++;
+        ring_buffer.end %= BUF_MAX;
+    } else {
+        /* full buffer detection */
+        ring_buffer.full = true;
+    }
+ end:
+    return;
+}
+
+/* functions implemented only when serial is activated */
+static inline void ring_buffer_write_digit(uint8_t digit)
+{
+    if (digit < 0xa) {
+        digit += '0';
+        ring_buffer_write_char(digit);
+    } else if (digit <= 0xf) {
+        digit += 'a' - 0xa;
+        ring_buffer_write_char(digit);
+    }
+}
+
+static void ring_buffer_write_number(uint64_t value, uint8_t base)
+{
+    /* we define a local storage to hold the digits list
+     * in any possible base up to base 2 (64 bits) */
+    uint8_t number[64] = { 0 };
+    int     index = 0;
+
+    for (; (value / base) != 0; value /= base) {
+        number[index++] = value % base;
+    }
+    /* finishing with most significant unit */
+    number[index++] = value % base;
+
+    /* Due to the last 'index++', index is targetting the first free cell.
+     * We make it points the last *used* cell instead */
+    index--;
+
+    /* now we can print out, starting with the most significant unit */
+    for (; index >= 0; index--) {
+        ring_buffer_write_digit(number[index]);
+    }
+}
+
+static inline void ring_buffer_write_string(char *str, uint32_t len)
+{
+    if (!str) {
+        goto end;
+    }
+    for (uint32_t i = 0; (i < len) && (str[i]); ++i) {
+        ring_buffer_write_char(str[i]);
+    }
+ end:
+    return;
+}
+
+
+
+
+#ifndef CONFIG_KERNEL_NOSERIAL
+/* flush behavior with activated serial... */
+void dbg_flush(void)
+{
+    if (console_putc == NULL) {
+        panic("Error: console_putc not initialized");
+    }
+    while (ring_buffer.start != ring_buffer.end) {
+        console_putc(ring_buffer.buf[ring_buffer.start++]);
+        ring_buffer.start %= BUF_MAX;
+    }
+}
+#else
+/* ... or in /dev/null mode */
+void dbg_flush(void)
+{
+    ring_buffer.start = ring_buffer.end;
+}
+#endif
+
+static uint8_t get_number_len(uint64_t value, uint8_t base)
+{
+    /* at least, if value is 0, its lenght is 1 digit */
+    uint8_t len = 1;
+
+    /* now we calculate the number of digits in the number */
+    for (; (value / base) != 0; value /= base) {
+        len++;
+    }
+    return len;
+}
+
+
+
+typedef enum {
+    FS_NUM_DECIMAL,
+    FS_NUM_HEX,
+    FS_NUM_UCHAR,
+    FS_NUM_SHORT,
+    FS_NUM_LONG,
+    FS_NUM_LONGLONG,
+    FS_NUM_UNSIGNED,
+} fs_num_mode_t;
+
+typedef struct {
+    bool    attr_0len;
+    bool    attr_size;
+    uint8_t size;
+    fs_num_mode_t numeric_mode;
+    bool    started;
+    uint8_t consumed;
+    uint32_t strlen;
+} fs_properties_t;
+
+
+
+
+static inline uint8_t print_handle_format_string(const char *fmt, va_list * args,
+                                          uint8_t * consumed,
+                                          uint32_t * out_str_len)
+{
+    fs_properties_t fs_prop = {
+        .attr_0len = false,
+        .attr_size = false,
+        .size = 0,
+        .numeric_mode = FS_NUM_DECIMAL, /*default */
+        .started = false,
+        .consumed = 0,
+        .strlen = 0
+    };
+
+    /*
+     * Sanitation
+     */
+    if (!fmt || !args || !consumed) {
+        return 1;
+    }
+
+    /* Let parse the format string ... */
+    do {
+        /*
+         * Handling '%' character
+         */
+        switch (fmt[fs_prop.consumed]) {
+            case '%':
+                {
+                    if (fs_prop.started == false) {
+                        /* starting string format parsing */
+                        fs_prop.started = true;
+                    } else if (fs_prop.consumed == 1) {
+                        /* detecting '%' just after '%' */
+                        ring_buffer_write_char('%');
+                        fs_prop.strlen++;
+                        /* => end of format string */
+                        goto end;
+                    } else {
+                        /* invalid: there is content before two '%' chars
+                         * in the same format_string (e.g. %02%) */
+                        goto err;
+                    }
+                    break;
+                }
+            case '0':
+                {
+                    /*
+                     * Handling '0' character
+                     */
+                    if (fs_prop.started == false) {
+                        goto err;
+                    }
+                    fs_prop.attr_0len = true;
+                    /* 0 must be completed with size content. We check it now */
+                    while ((fmt[fs_prop.consumed + 1] >= '0') &&
+                           (fmt[fs_prop.consumed + 1] <= '9')) {
+                        /* getting back the size. Here only decimal values are handled */
+                        fs_prop.size =
+                            (fs_prop.size * 10) +
+			    (fmt[fs_prop.consumed + 1] - '0');
+                        fs_prop.consumed++;
+                    }
+                    /* if digits have been found after the 0len format string, attr_size is
+                     * set to true
+                     */
+                    if (fs_prop.size != 0) {
+                        fs_prop.attr_size = true;
+                    }
+                    break;
+                }
+            case 'd':
+                {
+                    /*
+                     * Handling integers
+                     */
+                    if (fs_prop.started == false) {
+                        goto err;
+                    }
+                    fs_prop.numeric_mode = FS_NUM_DECIMAL;
+                    int     val = va_arg(*args, int);
+                    uint8_t len = get_number_len(val, 10);
+
+                    if (fs_prop.attr_size && fs_prop.attr_0len) {
+                        /* we have to pad with 0 the number to reach
+                         * the desired size */
+                        for (uint32_t i = len; i < fs_prop.size; ++i) {
+                            ring_buffer_write_char('0');
+                            fs_prop.strlen++;
+                        }
+                    }
+                    /* now we can print the number in argument */
+                    ring_buffer_write_number(val, 10);
+                    fs_prop.strlen += len;
+                    /* => end of format string */
+                    goto end;
+                }
+            case 'l':
+                {
+                    /*
+                     * Handling long and long long int
+                     */
+                    long    lval = 0;
+                    long long llval = 0;
+                    uint8_t len;
+
+                    if (fs_prop.started == false) {
+                        goto err;
+                    }
+                    fs_prop.numeric_mode = FS_NUM_LONG;
+                    /* detecting long long */
+                    if (fmt[fs_prop.consumed + 1] == 'l') {
+                        fs_prop.numeric_mode = FS_NUM_LONGLONG;
+                        fs_prop.consumed++;
+                    }
+                    if (fs_prop.numeric_mode == FS_NUM_LONG) {
+                        lval = va_arg(*args, long);
+
+                        len = get_number_len(lval, 10);
+                    } else {
+                        llval = va_arg(*args, long long);
+
+                        len = get_number_len(llval, 10);
+                    }
+                    if (fs_prop.attr_size && fs_prop.attr_0len) {
+                        /* we have to pad with 0 the number to reach
+                         * the desired size */
+                        for (uint32_t i = len; i < fs_prop.size; ++i) {
+                            ring_buffer_write_char('0');
+                            fs_prop.strlen++;
+                        }
+                    }
+                    /* now we can print the number in argument */
+                    if (fs_prop.numeric_mode == FS_NUM_LONG) {
+                        ring_buffer_write_number(lval, 10);
+                    } else {
+                        ring_buffer_write_number(llval, 10);
+                    }
+                    fs_prop.strlen += len;
+                    /* => end of format string */
+                    goto end;
+                }
+            case 'h': /* simplified through uint32_t cast */
+            case 'u':
+                {
+                    /*
+                     * Handling unsigned
+                     */
+                    if (fs_prop.started == false) {
+                        goto err;
+                    }
+                    fs_prop.numeric_mode = FS_NUM_UNSIGNED;
+                    uint32_t val = va_arg(*args, uint32_t);
+                    uint8_t len = get_number_len(val, 10);
+
+                    if (fs_prop.attr_size && fs_prop.attr_0len) {
+                        /* we have to pad with 0 the number to reach
+                         * the desired size */
+                        for (uint32_t i = len; i < fs_prop.size; ++i) {
+                            ring_buffer_write_char('0');
+                            fs_prop.strlen++;
+                        }
+                    }
+                    /* now we can print the number in argument */
+                    ring_buffer_write_number(val, 10);
+                    fs_prop.strlen += len;
+                    /* => end of format string */
+                    goto end;
+                }
+            case 'p':
+                {
+                    /*
+                     * Handling pointers. Include 0x prefix, as if using
+                     * %#x format string in POSIX printf.
+                     */
+                    if (fs_prop.started == false) {
+                        goto err;
+                    }
+                    uint32_t val = va_arg(*args, physaddr_t);
+                    uint8_t len = get_number_len(val, 16);
+
+                    ring_buffer_write_string("0x", 2);
+                    for (uint32_t i = len; i < fs_prop.size; ++i) {
+                        ring_buffer_write_char('0');
+                        fs_prop.strlen++;
+                    }
+                    /* now we can print the number in argument */
+                    ring_buffer_write_number(val, 16);
+                    fs_prop.strlen += len;
+                    /* => end of format string */
+                    goto end;
+                }
+
+            case 'x':
+                {
+                    /*
+                     * Handling hexadecimal
+                     */
+                    if (fs_prop.started == false) {
+                        goto err;
+                    }
+                    fs_prop.numeric_mode = FS_NUM_UNSIGNED;
+                    uint32_t val = va_arg(*args, uint32_t);
+                    uint8_t len = get_number_len(val, 16);
+
+                    if (fs_prop.attr_size && fs_prop.attr_0len) {
+                        /* we have to pad with 0 the number to reach
+                         * the desired size */
+                        for (uint32_t i = len; i < fs_prop.size; ++i) {
+                            ring_buffer_write_char('0');
+                            fs_prop.strlen++;
+                        }
+                    }
+                    /* now we can print the number in argument */
+                    ring_buffer_write_number(val, 16);
+                    fs_prop.strlen += len;
+                    /* => end of format string */
+                    goto end;
+                }
+            case 'o':
+                {
+                    /*
+                     * Handling octal
+                     */
+                    if (fs_prop.started == false) {
+                        goto err;
+                    }
+                    fs_prop.numeric_mode = FS_NUM_UNSIGNED;
+                    uint32_t val = va_arg(*args, uint32_t);
+                    uint8_t len = get_number_len(val, 8);
+
+                    if (fs_prop.attr_size && fs_prop.attr_0len) {
+                        /* we have to pad with 0 the number to reach
+                         * the desired size */
+                        for (uint32_t i = len; i < fs_prop.size; ++i) {
+                            ring_buffer_write_char('0');
+                            fs_prop.strlen++;
+                        }
+                    }
+                    /* now we can print the number in argument */
+                    ring_buffer_write_number(val, 8);
+                    fs_prop.strlen += len;
+
+                    /* => end of format string */
+                    goto end;
+                }
+            case 's':
+                {
+                    /*
+                     * Handling strings
+                     */
+                    if (fs_prop.started == false) {
+                        goto err;
+                    }
+                    /* no size or 0len attribute for strings */
+                    if (fs_prop.attr_size && fs_prop.attr_0len) {
+                        goto err;
+                    }
+                    char   *str = va_arg(*args, char *);
+
+                    /* now we can print the number in argument */
+                    ring_buffer_write_string(str, strlen(str));
+                    fs_prop.strlen += strlen(str);
+
+                    /* => end of format string */
+                    goto end;
+                }
+ 
+                /* none of the above. Unsupported format */
+            default:
+                {
+                    /* should not happend, unable to parse format string */
+                    goto err;
+                    break;
+                }
+
+        }
+        fs_prop.consumed++;
+    } while (fmt[fs_prop.consumed]);
+ end:
+    *out_str_len += fs_prop.strlen;
+    *consumed = fs_prop.consumed + 1;   /* consumed is starting with 0 */
+    return 0;
+ err:
+    *out_str_len += fs_prop.strlen;
+    *consumed = fs_prop.consumed + 1;   /* consumed is starting with 0 */
+    return 1;
+}
+
+
+static int print(const char *fmt, va_list args, logsize_t *sizew)
+{
+    int     i = 0;
+    uint8_t consumed = 0;
+    uint32_t out_str_s = 0;
+
+    while (fmt[i]) {
+        if (fmt[i] == '%') {
+            if (print_handle_format_string
+                (&(fmt[i]), &args, &consumed, &out_str_s)) {
+                /* the string format parsing has failed ! */
+                goto err;
+            }
+            i += consumed;
+            consumed = 0;
+        } else if (fmt[i] == '\n') {
+		/* carriage return and line breaks are both requested
+		 * on USART line */
+		ring_buffer_write_string("\r\n", 2);
+		out_str_s += 2;
+		i++;
+	} else {
+            out_str_s++;
+            ring_buffer_write_char(fmt[i++]);
+        }
+    }
+    *sizew = out_str_s;
+    return 0;
+ err:
+    *sizew = out_str_s;
+    return -1;
+}
+
+int dbg_log(const char *fmt, ...)
+{
+    int     res = -1;
+    va_list args;
+    logsize_t  len;
+
+    /*
+     * if there is some asyncrhonous printf to pass to the kernel, do it
+     * before execute the current printf command
+     */
+    va_start(args, fmt);
+    res = print(fmt, args, &len);
+    va_end(args);
+    if (res == -1) {
+        ring_buffer_reset();
+        goto err;
+    }
+ err:
+    return res;
+}
+
+/* WARNING: in NOSERIAL mode, panic doesn't printout any information */
+void panic(char *fmt, ...)
+{
+    va_list args;
+    logsize_t  len;
+
+    va_start(args, fmt);
+    print(fmt, args, &len);
+    va_end(args);
+    dbg_flush();
+#if CONFIG_KERNEL_PANIC_FREEZE 
+    while (1)
+        continue;
+#elif CONFIG_KERNEL_PANIC_REBOOT
+    NVIC_SystemReset();
+    /* and wait... */
+    while (1);
+#else
+    /* fallback */
+    while (1)
+        continue;
+#endif
+}

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,24 +1,35 @@
-/* \file debug.c
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #include "stdarg.h"
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,24 +1,35 @@
-/* \file debug.c
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef DEBUG_H_
 #define DEBUG_H_

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,0 +1,108 @@
+/* \file debug.c
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef DEBUG_H_
+#define DEBUG_H_
+
+#include "autoconf.h"
+#ifdef CONFIG_ARCH_CORTEX_M4
+#include "m4-systick.h"
+#else
+#error "no systick support for other by now!"
+#endif
+#include "soc-usart.h"
+
+/**
+ * This is the DBGLOG log levels definition. This is syslog compatible
+ */
+typedef enum {
+    DBG_EMERG = 0,
+    DBG_ALERT = 1,
+    DBG_CRIT = 2,
+    DBG_ERR = 3,
+    DBG_WARN = 4,
+    DBG_NOTICE = 5,
+    DBG_INFO = 6,
+    DBG_DEBUG = 7,
+} e_dbglevel_t;
+
+/**
+ * dbg_log - log strings in ring buffer
+ * @fmt: format string
+ */
+int dbg_log(const char *fmt, ...);
+
+/**
+ * menuconfig controlled debug print
+ */
+#define DEBUG(level, fmt, ...) {  \
+  if (level <= CONFIG_DBGLEVEL) {  dbg_log(fmt, __VA_ARGS__); dbg_flush(); } \
+}
+
+void debug_console_init(void);
+
+/**
+ * dbg_flush - flush the ring buffer to UART
+ */
+void dbg_flush(void);
+
+/**
+ * panic - output string on UART, flush ring buffer and stop
+ * @fmt: format string
+ */
+void panic(char *fmt, ...);
+
+#define assert(EXP)									\
+	do {										\
+		if (!(EXP))								\
+			panic("Assert in file %s on line %d\n", __FILE__, __LINE__);	\
+	} while (0)
+
+#if DEBUG_LVL >= 3
+#define LOG(fmt, ...) dbg_log("%lld: [II] %s:%d, %s:"fmt, get_ticks(), __FILE__, __LINE__,  __FUNCTION__, ##__VA_ARGS__)
+#else
+#define LOG(fmt, ...) do {} while (0)
+#endif
+
+#if DEBUG_LVL >= 2
+#define WARN(fmt, ...) dbg_log("%lld: [WW] %s:%d, %s:"fmt, get_ticks(), __FILE__, __LINE__,  __FUNCTION__, ##__VA_ARGS__)
+#else
+#define WARN(fmt, ...) do {} while (0)
+#endif
+
+#if DEBUG_LVL >= 1
+extern volatile int logging;
+#define ERROR(fmt, ...)							\
+	do {									\
+		dbg_log("%lld: [EE] %s:%d, %s:"fmt, get_ticks(), __FILE__, __LINE__,  __FUNCTION__, ##__VA_ARGS__);	\
+		/*if (logging)*/							\
+			dbg_flush();						\
+	} while (0)
+#else
+#define ERROR(fmt, ...) do {} while (0)
+#endif
+
+#define LOG_CL(fmt, ...) dbg_log(""fmt, ##__VA_ARGS__)
+
+void init_ring_buffer(void);
+
+#endif /* !DEBUG_H_ */

--- a/src/default_handlers.c
+++ b/src/default_handlers.c
@@ -9,6 +9,10 @@
 /*
 ** Generic handlers. This handlers can be overloaded later if needed.
 */
+#define interrupt_get_num(intr) { asm volatile ("mrs r1, ipsr\n\t" \
+                                                "mov %0, r1\n\t" \
+                                              : "=r" (intr) :: "r1" ); }
+
 
 
 stack_frame_t *HardFault_Handler(stack_frame_t * frame)

--- a/src/default_handlers.c
+++ b/src/default_handlers.c
@@ -1,3 +1,36 @@
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 #include "autoconf.h"
 #include "soc-interrupts.h"
 #include "soc-nvic.h"

--- a/src/default_handlers.c
+++ b/src/default_handlers.c
@@ -10,103 +10,6 @@
 ** Generic handlers. This handlers can be overloaded later if needed.
 */
 
-static inline void exti_handle_line(uint8_t        exti_line,
-                                    uint8_t        irq,
-                                    stack_frame_t *stack_frame __attribute__((unused)))
-{
-    gpioref_t   kref;
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion"
-    /* No possible typecasting from uint8_t to :4 */
-    kref.pin = exti_line;
-#pragma GCC diagnostic pop
-
-    /* Clear the EXTI pending bit for this line */
-    soc_exti_clear_pending(kref.pin);
-
-    /* Get back the configured GPIO port for this line */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion"
-    /* No possible typecasting from uint8_t to :4 */
-    kref.port = soc_exti_get_syscfg_exticr_port(kref.pin);
-#pragma GCC diagnostic pop
-
-    NVIC_ClearPendingIRQ((uint32_t)(irq - 0x10));
-#ifdef CONFIG_FIRMWARE_DFU
-    exti_button_handler(irq, 0, 0);
-#endif
-
-}
-
-
-stack_frame_t *exti_handler(stack_frame_t * stack_frame)
-{
-    uint8_t  int_num;
-    uint32_t pending_lines = 0;
-
-    /*
-     * It's sad to get back again the IRQ here, but as a generic kernel
-     * IRQ handler, the IRQ number is not passed as first argument
-     * Only postpone_isr get it back.
-     * TODO: give irq as first argument of *all* handler ?
-     */
-    interrupt_get_num(int_num);
-    int_num &= 0x1ff;
-
-    switch (int_num) {
-        /* EXTI0: pin 0 */
-        case EXTI0_IRQ: {
-            exti_handle_line(0, int_num, stack_frame);
-            break;
-        }
-        /* EXTI0: pin 1 */
-        case EXTI1_IRQ: {
-            exti_handle_line(1, int_num, stack_frame);
-            break;
-        }
-        /* EXTI0: pin 2 */
-        case EXTI2_IRQ: {
-            exti_handle_line(2, int_num, stack_frame);
-            break;
-        }
-        /* EXTI0: pin 3 */
-        case EXTI3_IRQ: {
-            exti_handle_line(3, int_num, stack_frame);
-            break;
-        }
-        /* EXTI0: pin 4 */
-        case EXTI4_IRQ: {
-            exti_handle_line(4, int_num, stack_frame);
-            break;
-        }
-        /* EXTI0: pin 5 to 9 */
-        case EXTI9_5_IRQ: {
-            pending_lines = soc_exti_get_pending_lines(int_num);
-            for (uint8_t i = 0; i < 5; ++i) {
-                if (pending_lines & (uint32_t)(0x1 << i)) {
-                     exti_handle_line((uint8_t)(5 + i), int_num, stack_frame);
-                }
-            }
-            break;
-        }
-        /* EXTI0: pin 10 to 15 */
-        case EXTI15_10_IRQ:
-            pending_lines = soc_exti_get_pending_lines(int_num);
-            for (uint8_t i = 0; i < 6; ++i) {
-                if (pending_lines & (uint32_t)(0x1 << i)) {
-                     exti_handle_line((uint8_t)(10 + i), int_num, stack_frame);
-                }
-            }
-            break;
-        default:
-            break;
-    }
-    return stack_frame;
-}
-
-
-
 
 stack_frame_t *HardFault_Handler(stack_frame_t * frame)
 {
@@ -114,17 +17,8 @@ stack_frame_t *HardFault_Handler(stack_frame_t * frame)
     uint32_t    hfsr = *((volatile uint32_t *) r_CORTEX_M_SCB_HFSR);
     uint32_t   *p;
     int         i;
-#ifdef KERNEL
-    task_t     *current_task = sched_get_current();
-    if (!current_task) {
-        /* This happend when hardfaulting before sched module initialization */
-        dbg_log("\nEarly kernel hard fault\n  scb.hfsr %x  scb.cfsr %x\n", hfsr, cfsr);
-    } else {
-        dbg_log("\nHard fault from %s\n  scb.hfsr %x  scb.cfsr %x\n", current_task->name, hfsr, cfsr);
-    }
-#else
+
     dbg_log("\nHard fault\n  scb.hfsr %x  scb.cfsr %x\n", hfsr, cfsr);
-#endif
     dbg_flush();
 
     dbg_log("-- registers (frame at %x, EXC_RETURN  %x)\n", frame, frame->lr);
@@ -145,20 +39,8 @@ stack_frame_t *HardFault_Handler(stack_frame_t * frame)
         dbg_flush();
         p = p + 4;
     }
-#ifdef KERNEL
-    if (frame_is_kernel((physaddr_t)frame)) {
-        panic("Oops! Kernel panic!\n");
-    }
-    /*
-     * here current_task can't be null as the frame is user
-     * (i.e. the sched module is already started)
-     */
-    current_task->state[current_task->mode] = TASK_STATE_FAULT;
-    request_schedule();
-#else
     /* Non kernel mode (e.g. loader mode) */
     panic("Oops! Kernel panic!\n");
-#endif
     return frame;
 }
 
@@ -187,27 +69,6 @@ __ISR_HANDLER stack_frame_t *Default_SubHandler(stack_frame_t * stack_frame)
 
     if (int_num == 3) {
         HardFault_Handler(stack_frame);
-    }
-    if (int_num == EXTI0_IRQ) {
-        exti_handler(stack_frame);
-    }
-    if (int_num == EXTI1_IRQ) {
-        exti_handler(stack_frame);
-    }
-    if (int_num == EXTI2_IRQ) {
-        exti_handler(stack_frame);
-    }
-    if (int_num == EXTI3_IRQ) {
-        exti_handler(stack_frame);
-    }
-    if (int_num == EXTI4_IRQ) {
-        exti_handler(stack_frame);
-    }
-    if (int_num == EXTI9_5_IRQ) {
-        exti_handler(stack_frame);
-    }
-    if (int_num == EXTI15_10_IRQ) {
-        exti_handler(stack_frame);
     }
 
     asm volatile

--- a/src/default_handlers.h
+++ b/src/default_handlers.h
@@ -1,3 +1,40 @@
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef DEFAULT_HANDLERS_H_
+#define DEFAULT_HANDLERS_H_
 
 stack_frame_t *HardFault_Handler(stack_frame_t * frame);
 stack_frame_t *Default_SubHandler(stack_frame_t * stack_frame);
+
+#endif/*!DEFAULT_HANDLERS_H_*/

--- a/src/flash.c
+++ b/src/flash.c
@@ -1,3 +1,36 @@
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 /** @file flash.c
  * \brief File includes functions to manipulate flash memory.
  *

--- a/src/flash.h
+++ b/src/flash.h
@@ -1,3 +1,36 @@
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 #ifndef _STM32F4XX_FLASH_H
 #define _STM32F4XX_FLASH_H
 

--- a/src/flash_regs.h
+++ b/src/flash_regs.h
@@ -1,3 +1,36 @@
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 #ifndef FLASH_REGS_H_
 #define FLASH_REGS_H_
 

--- a/src/gpio.h
+++ b/src/gpio.h
@@ -1,0 +1,241 @@
+/*
+ * \file gpio.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef KERNEL_GPIO_H
+#define KERNEL_GPIO_H
+/*
+ * Remember to include libstd types.h header for stdint support
+ */
+
+/**< The maximum number of GPIO lines per device*/
+#define MAX_GPIOS 16
+
+typedef void (*user_handler_t) (uint8_t irq, uint32_t status, uint32_t data);
+
+/*
+ * GPIO Alternate functions (numeric values)
+ */
+typedef enum {
+    GPIO_AF_AF0   =  0x0,
+    GPIO_AF_AF1   =  0x1,
+    GPIO_AF_AF2   =  0x2,
+    GPIO_AF_AF3   =  0x3,
+    GPIO_AF_AF4   =  0x4,
+    GPIO_AF_AF5   =  0x5,
+    GPIO_AF_AF6   =  0x6,
+    GPIO_AF_AF7   =  0x7,
+    GPIO_AF_AF8   =  0x8,
+    GPIO_AF_AF9   =  0x9,
+    GPIO_AF_AF10  =  0xa,
+    GPIO_AF_AF11  =  0xb,
+    GPIO_AF_AF12  =  0xc,
+    GPIO_AF_AF13  =  0xd,
+    GPIO_AF_AF14  =  0xe,
+    GPIO_AF_AF15  =  0xf
+} gpio_af_t;
+
+/*
+ * GPIO alternate functions
+ * human readable values, using macros, these are still gpio_af_t.
+ */
+#define GPIO_AF_SYSTEM      GPIO_AF_AF0
+#define GPIO_AF_TIM1        GPIO_AF_AF1
+#define GPIO_AF_TIM2        GPIO_AF_AF1
+#define GPIO_AF_TIM3        GPIO_AF_AF2
+#define GPIO_AF_TIM4        GPIO_AF_AF2
+#define GPIO_AF_TIM5        GPIO_AF_AF2
+#define GPIO_AF_TIM8        GPIO_AF_AF3
+#define GPIO_AF_TIM9        GPIO_AF_AF3
+#define GPIO_AF_TIM10       GPIO_AF_AF3
+#define GPIO_AF_TIM11       GPIO_AF_AF3
+#define GPIO_AF_I2C1        GPIO_AF_AF4
+#define GPIO_AF_I2C2        GPIO_AF_AF4
+#define GPIO_AF_I2C3        GPIO_AF_AF4
+#define GPIO_AF_SPI1        GPIO_AF_AF5
+#define GPIO_AF_SPI2        GPIO_AF_AF5
+#define GPIO_AF_SPI3        GPIO_AF_AF6
+#define GPIO_AF_USART1      GPIO_AF_AF7
+#define GPIO_AF_USART2      GPIO_AF_AF7
+#define GPIO_AF_USART3      GPIO_AF_AF7
+#define GPIO_AF_USART4      GPIO_AF_AF8
+#define GPIO_AF_UART4       GPIO_AF_AF8
+#define GPIO_AF_USART5      GPIO_AF_AF8
+#define GPIO_AF_UART5       GPIO_AF_AF8
+#define GPIO_AF_USART6      GPIO_AF_AF8
+#define GPIO_AF_CAN1        GPIO_AF_AF9
+#define GPIO_AF_CAN2        GPIO_AF_AF9
+#define GPIO_AF_TIM12       GPIO_AF_AF9
+#define GPIO_AF_TIM13       GPIO_AF_AF9
+#define GPIO_AF_TIM14       GPIO_AF_AF9
+#define GPIO_AF_OTG_FS      GPIO_AF_AF10
+#define GPIO_AF_OTG_HS      GPIO_AF_AF10
+#define GPIO_AF_ETH         GPIO_AF_AF11
+#define GPIO_AF_FSMC        GPIO_AF_AF12
+#define GPIO_AF_SDIO        GPIO_AF_AF12
+#define GPIO_AF_OTG_HS_FS   GPIO_AF_AF12
+#define GPIO_AF_DCMI        GPIO_AF_AF13
+#define GPIO_AF_EVENTOUT    GPIO_AF_AF15
+
+/**
+ * GPIO inputs mode
+ */
+typedef enum {
+	GPIO_NOPULL = 0,
+		   /**< GPIO pin in No Pull mode */
+	GPIO_PULLUP = 1,
+		   /**< GPIO pin in Pull UP mode */
+	GPIO_PULLDOWN = 2,
+		   /**< GPIO pin in Pull Down mode */
+} gpio_pupd_t;
+
+/**
+ * GPIO direction
+ */
+typedef enum {
+	GPIO_PIN_INPUT_MODE = 0,
+			   /**< GPIO pin in input mode */
+	GPIO_PIN_OUTPUT_MODE = 1,
+			   /**< GPIO pin in output mode */
+	GPIO_PIN_ALTERNATE_MODE = 2,
+			   /**< GPIO pin in anternative mode */
+	GPIO_PIN_ANALOG_MODE = 3
+			   /**< GPIO pin in analogic mode */
+} gpio_mode_t;
+
+/**
+ * GPIO speed, depending on the value measured (timer, sensor...)
+ */
+typedef enum {
+	GPIO_PIN_LOW_SPEED = 0,
+			   /**< GPIO pin in low speed mode */
+	GPIO_PIN_MEDIUM_SPEED = 1,
+			   /**< GPIO pin in medium speed mode */
+	GPIO_PIN_HIGH_SPEED = 2,
+			   /**< GPIO pin in high speed mode */
+	GPIO_PIN_VERY_HIGH_SPEED = 3,
+			   /**< GPIO pin in very high speed mode */
+} gpio_speed_t;
+
+/**
+ * GPIO ouputs mode
+ */
+typedef enum {
+	GPIO_PIN_OTYPER_PP = 0,
+			  /**< GPIO pin in Push-Pull mode */
+	GPIO_PIN_OTYPER_OD = 1,
+			  /**< GPIO pin in Open-Drain mode */
+} gpio_type_t;
+
+
+typedef enum {
+  GPIO_MASK_SET_MODE  = 0b000000001,
+  GPIO_MASK_SET_TYPE  = 0b000000010,
+  GPIO_MASK_SET_SPEED = 0b000000100,
+  GPIO_MASK_SET_PUPD  = 0b000001000,
+  GPIO_MASK_SET_BSR_R = 0b000010000,
+  GPIO_MASK_SET_BSR_S = 0b000100000,
+  GPIO_MASK_SET_LCK   = 0b001000000,
+  GPIO_MASK_SET_AFR   = 0b010000000,
+  GPIO_MASK_SET_EXTI  = 0b100000000,
+  GPIO_MASK_SET_ALL   = 0b111111111,
+} gpio_mask_t;
+
+
+typedef enum {
+    /** No EXTI line for this GPIO */
+  GPIO_EXTI_TRIGGER_NONE = 0,
+    /** Trigger intterupt on rising edge only */
+  GPIO_EXTI_TRIGGER_RISE,
+    /** Trigger intterupt on falling edge only */
+  GPIO_EXTI_TRIGGER_FALL,
+    /** Trigger intterupt on both rising and falling edges */
+  GPIO_EXTI_TRIGGER_BOTH
+} gpio_exti_trigger_t;
+
+/*
+ * Lock EXTI line when the EXTI interrupt arrise ?
+ */
+typedef enum {
+  /** Don't lock EXTI line, other EXTI interrupts can continue to arrise */
+  GPIO_EXTI_UNLOCKED = 0,
+  /** Lock EXTI line at handler time, the ISR has to voluntary re-enable it */
+  GPIO_EXTI_LOCKED
+} gpio_exti_lock_t;
+
+/**
+** \brief This is the GPIO informational structure for user drivers
+**
+** A device may require GPIO configuration. If yes,
+** this structure must be fullfill by the userspace but the
+** configuration is done by the kernel (no direct mapping of
+** the GPIO configuration registers)
+*/
+typedef union {
+    struct {
+        unsigned char pin  : 4;
+        unsigned char port : 4;
+    };
+    unsigned char val;
+} gpioref_t;
+
+/* GPIO ports */
+#define GPIO_PA 0
+#define GPIO_PB 1
+#define GPIO_PC 2
+#define GPIO_PD 3
+#define GPIO_PE 4
+#define GPIO_PF 5
+#define GPIO_PG 6
+#define GPIO_PH 7
+#define GPIO_PI 8
+
+typedef struct {
+    gpio_mask_t mask;
+
+    /**< GPIO kernel reference
+     *   = concatenation of the GPIO port (4 bits) and the pin number (4 bits)
+     *
+     *   If set at 1 before registration, the kernel will dynamicaly allocate
+     *   a free port/pin and update kref accordingly.
+     *
+     *   If set to 0 before registration, the kernel will use port & pin
+     *   directly. GPIO port use at registration are named using 'A', 'B', ...
+     *   up to the last GPIO port available (e.g. 'I' for STM32F4xx)
+     */
+	gpioref_t           kref;
+
+	gpio_mode_t         mode;
+	gpio_pupd_t         pupd;
+	gpio_type_t         type;
+	gpio_speed_t        speed;
+	uint32_t            afr;
+	uint32_t            bsr_r;
+	uint32_t            bsr_s;
+	uint32_t            lck;
+    gpio_exti_trigger_t exti_trigger;
+    gpio_exti_lock_t    exti_lock;
+	user_handler_t      exti_handler;
+
+} dev_gpio_info_t;
+
+#endif

--- a/src/gpio.h
+++ b/src/gpio.h
@@ -1,25 +1,35 @@
 /*
- * \file gpio.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef KERNEL_GPIO_H
 #define KERNEL_GPIO_H

--- a/src/hash.c
+++ b/src/hash.c
@@ -1,3 +1,36 @@
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 #include "hash.h"
 #include "regutils.h"
 #include "debug.h"

--- a/src/hash.h
+++ b/src/hash.h
@@ -1,3 +1,36 @@
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 #ifndef HASH_H_
 #define HASH_H_
 

--- a/src/libc.c
+++ b/src/libc.c
@@ -1,0 +1,157 @@
+/* \file libc.c
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include "types.h"
+
+void *memset(void *s, int c, uint32_t n)
+{
+    char *bytes = s;
+    while (n) {
+        *bytes = c;
+        bytes++;
+        n--;
+    }
+    return s;
+}
+
+void *memcpy(void *dest, const void *src, uint32_t n)
+{
+    char *d_bytes = dest;
+    const char *s_bytes = src;
+
+    while (n) {
+        *d_bytes = *s_bytes;
+        d_bytes++;
+        s_bytes++;
+        n--;
+    }
+
+    return dest;
+}
+
+uint32_t strlen(const char *s)
+{
+    uint32_t i = 0;
+    if (!s) {
+        return 0;
+    }
+    while (*s) {
+        i++;
+        s++;
+    }
+    return i;
+}
+
+char *strncpy(char *dest, const char *src, uint32_t n)
+{
+    char *return_value = dest;
+
+    if (!src || !dest) {
+        return return_value;
+    }
+    while (n && *src) {
+        *dest = *src;
+        dest++;
+        src++;
+        n--;
+    }
+
+    while (n) {
+        *dest = 0;
+        dest++;
+        n--;
+    }
+
+    return return_value;
+}
+
+int8_t strcmp(const char *a, const char *b)
+{
+    unsigned char len = 0;
+
+    if (!a || !b) {
+       if (!a && !b) {
+           return 0;
+       }
+       if (!a) {
+           return -1;
+       }
+       if (!b) {
+           return 1;
+       }
+    }
+    while (1) {
+        if (a[len] != b[len] || a[len] == '\0' || b[len] == '\0') {
+            return a[len] - b[len];
+        }
+        len++;
+    }
+}
+
+char tolower (char c) {
+    if (c >= 'A' && c <= 'Z') {
+        return c + ('a' - 'A');
+    } else {
+        return c;
+    }
+}
+
+int8_t strcasecmp(const char *a, const char *b)
+{
+    char c1, c2;
+    uint8_t len = 0;
+
+    if (!a || !b) {
+       if (!a && !b) {
+           return 0;
+       }
+       if (!a) {
+           return -1;
+       }
+       if (!b) {
+           return 1;
+       }
+    }
+
+    while (1) {
+        c1 = tolower(a[len]);
+        c2 = tolower(b[len]);
+
+        if (c1 != c2 || c1 == '\0' || c2 == '\0') {
+            return c1 - c2;
+        }
+
+        len++;
+    }
+}
+
+
+void sleep_intern(uint8_t length)
+{
+    /* FIXME Assert length value */
+    int i = 0, j = 0;
+    int time_value = (1 << (length * 2));
+    for (i = 0; i < time_value; i++) {
+        for (j = 0; j < time_value; j++) ;
+    }
+}

--- a/src/libc.c
+++ b/src/libc.c
@@ -1,24 +1,35 @@
-/* \file libc.c
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "types.h"

--- a/src/libc.h
+++ b/src/libc.h
@@ -1,0 +1,24 @@
+#ifndef _LIBC_
+#define _LIBC_
+
+#include "types.h"
+
+/*
+ * Define time to sleep (for loop)
+ */
+#define MICRO_TIME  	1
+#define SHORT_TIME  	3
+#define MEDIUM_TIME 	5
+#define LONG_TIME   	6
+#define DFU_TIME    	24
+
+void *memset(void *s, int c, uint32_t n);
+void *memcpy(void *dest, const void *src, uint32_t n);
+uint32_t strlen(const char *s);
+char *strncpy(char *dest, const char *src, uint32_t n);
+char tolower (char c);
+int8_t strcmp(const char *a, const char *b);
+int8_t strcasecmp(const char *a, const char *b);
+void sleep_intern(uint8_t length);
+
+#endif                          /* _LIBC_ */

--- a/src/libc.h
+++ b/src/libc.h
@@ -1,3 +1,36 @@
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 #ifndef _LIBC_
 #define _LIBC_
 

--- a/src/main.c
+++ b/src/main.c
@@ -15,18 +15,18 @@
 #include "soc-init.h"
 #include "soc-usart.h"
 #include "soc-usart-regs.h"
-#include "soc-layout.h"
+//#include "soc-layout.h"
 #include "soc-gpio.h"
 #include "soc-nvic.h"
 #include "soc-rcc.h"
 #include "soc-interrupts.h"
 #include "boot_mode.h"
-#include "stack_check.h"
 #include "shr.h"
 #include "crc32.h"
-#include "C/exported/gpio.h"
+#include "gpio.h"
 #include "types.h"
 #include "flash.h"
+
 
 #define COLOR_NORMAL  "\033[0m"
 #define COLOR_REVERSE "\033[7m"
@@ -123,7 +123,6 @@ int main(void)
     system_init((uint32_t) LDR_BASE);
     core_systick_init();
     // button now managed at kernel boot to detect if DFU mode
-    //d_button_init();
     debug_console_init();
 
     enable_irq();

--- a/src/main.c
+++ b/src/main.c
@@ -1,3 +1,36 @@
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 /** @file main.c
  *
  */

--- a/src/main.h
+++ b/src/main.h
@@ -1,3 +1,36 @@
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 #ifndef MAIN_H_
 #define MAIN_H_
 

--- a/src/regutils.h
+++ b/src/regutils.h
@@ -1,3 +1,36 @@
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 #ifndef REGUTILS_H_
 #define REGUTILS_H_
 #include "types.h"

--- a/src/shr.c
+++ b/src/shr.c
@@ -1,24 +1,35 @@
-/* \file shr.c
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
 /*!

--- a/src/shr.h
+++ b/src/shr.h
@@ -1,24 +1,35 @@
-/* \file shr.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef _SHARED_H
 #define _SHARED_H

--- a/src/types.h
+++ b/src/types.h
@@ -1,24 +1,35 @@
-/* \file types.h
- *
- * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+/*
+ * Copyright 2019 The wookey project team <wookey@ssi.gouv.fr>
  *   - Ryad     Benadjila
  *   - Arnauld  Michelizza
  *   - Mathieu  Renard
  *   - Philippe Thierry
  *   - Philippe Trebuchet
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of mosquitto nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- *     Unless required by applicable law or agreed to in writing, software
- *     distributed under the License is distributed on an "AS IS" BASIS,
- *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *     See the License for the specific language governing permissions and
- *     limitations under the License.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef TYPES_H_
 #define TYPES_H_

--- a/src/types.h
+++ b/src/types.h
@@ -1,0 +1,34 @@
+/* \file types.h
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+#ifndef TYPES_H_
+#define TYPES_H_
+
+#include "autoconf.h"
+
+#ifdef CONFIG_ARCH_ARMV7M
+# include "arch/cores/armv7-m/types.h"
+#else
+# error "architecture not yet supported"
+#endif
+
+#endif/*!TYPES_H_*/


### PR DESCRIPTION
## Making bootloader sources autonomous

From now on, the bootloader BSP was based on the kernel BSP, making EwoK BSP sources impacting the bootloader compilation and API.

This patch update the bootloader with a reduced BSP, including only the requested support. This is done by:
   1. Removing EXTI usage, replaced by GPIO polling
   2. Adding requested missing BSP sources from the kernel to the bootloader, allowing te kernel to evolve withtout any external dependencies

The bootloader BSP is reduced to the minimal requested content, i.e. support for RCC, PWR, USART, basic interrupts and NVIC, basic GPIO (for Wookey DFU button). Other part of the BSP (layouting, dynamic mechanisms) are purged.

This PR is the first of two PRs, the second is a small patch in the tataouine SDK, requested to remove the dependency between loader and kernel's libbsp. This second patch is not required to make this patch work and is only a cleaning patch.
