### PR TITLE
[enhancement] transition-centric automaton based bootloader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ CFLAGS += $(KERN_CFLAGS)
 CFLAGS += $(LIBSIGN_CFLAGS) -I$(PROJ_FILES)/externals/libecc/src
 CFLAGS += -Isrc/ -Iinc/ -Isrc/arch -Isrc/arch/cores/$(ARCH) -Isrc/arch/socs/$(SOC)
 CFLAGS += -MMD -MP
+CFLAGS += -O0 # required by hardened programing
 
 LDFLAGS := -Tloader.ld $(AFLAGS) -fno-builtin -nostdlib -nostartfiles -Wl,-Map=$(APP_BUILD_DIR)/$(APP_NAME).map
 LD_LIBS += -lsign -L$(APP_BUILD_DIR) -L$(BUILD_DIR)/externals

--- a/src/automaton.c
+++ b/src/automaton.c
@@ -1,0 +1,219 @@
+/*
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * This package is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * ur option) any later version.
+ *
+ * This package is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this package; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+#include "autoconf.h"
+#include "automaton.h"
+#include "main.h"
+
+
+/****************************************************************
+ * loader state automaton formal definition and associate utility
+ * functions
+ ***************************************************************/
+
+static loader_state_t state;
+
+/*
+ * all allowed transitions and target states for each current state
+ * empty fields are set as 0xff/0xff for request/state couple, which is
+ * an inexistent state and request
+ *
+ * This table associate each state of the DFU automaton with up to
+ * 5 potential allowed transitions/next_state couples. This permit to
+ * easily detect:
+ *    1) authorized transitions, based on the current state
+ *    2) next state, based on the current state and current transition
+ *
+ * If the next_state for the current transision is keeped to 0xff, this
+ * means that the current transition for the current state may lead to
+ * multiple next state depending on other informations. In this case,
+ * the transition handler has to handle this manually.
+ */
+
+#define MAX_TRANSITION_STATE 3
+
+/*
+ * Association between a request and a transition to a next state. This couple
+ * depend on the current state and is use in the following structure
+ */
+typedef struct loader_operation_code_transition {
+    loader_request_t request;
+    loader_state_t   target_state;
+} loader_operation_code_transition_t;
+
+
+static const struct {
+    loader_state_t state;
+    loader_operation_code_transition_t req_trans[MAX_TRANSITION_STATE];
+} loader_automaton[] = {
+    {LOADER_START, {
+                 {LOADER_REQ_ERROR, LOADER_ERROR},
+                 {LOADER_REQ_SECBREACH, LOADER_SECBREACH},
+                 {LOADER_REQ_INIT, LOADER_INIT},
+                  }
+    },
+    {LOADER_INIT, {
+                 {LOADER_REQ_ERROR, LOADER_ERROR},
+                 {LOADER_REQ_SECBREACH, LOADER_SECBREACH},
+                 {LOADER_REQ_RDPCHECK, LOADER_RDPCHECK},
+                 }
+     },
+    {LOADER_RDPCHECK, {
+                 {LOADER_REQ_ERROR, LOADER_ERROR},
+                 {LOADER_REQ_SECBREACH, LOADER_SECBREACH},
+                 {LOADER_REQ_DFUCHECK, LOADER_DFUWAIT},
+                 }
+     },
+    {LOADER_DFUWAIT, {
+                 {LOADER_REQ_ERROR, LOADER_ERROR},
+                 {LOADER_REQ_SECBREACH, LOADER_SECBREACH},
+                 {LOADER_REQ_SELECTBANK, LOADER_SELECTBANK},
+                 }
+     },
+    {LOADER_SELECTBANK, {
+                 {LOADER_REQ_ERROR, LOADER_ERROR},
+                 {LOADER_REQ_SECBREACH, LOADER_SECBREACH},
+                 {LOADER_REQ_CRCCHECK, LOADER_HDRCRC},
+                 }
+     },
+    {LOADER_HDRCRC, {
+                 {LOADER_REQ_ERROR, LOADER_ERROR},
+                 {LOADER_REQ_SECBREACH, LOADER_SECBREACH},
+                 {LOADER_REQ_INTEGRITYCHECK, LOADER_FWINTEGRITY},
+                 }
+     },
+    {LOADER_FWINTEGRITY, {
+                 {LOADER_REQ_ERROR, LOADER_ERROR},
+                 {LOADER_REQ_SECBREACH, LOADER_SECBREACH},
+                 {LOADER_REQ_FLASHLOCK, LOADER_FLASHLOCK},
+                 }
+     },
+    {LOADER_FLASHLOCK, {
+                 {LOADER_REQ_ERROR, LOADER_ERROR},
+                 {LOADER_REQ_SECBREACH, LOADER_SECBREACH},
+                 {LOADER_REQ_BOOT, LOADER_BOOTFW},
+                 }
+     },
+    {LOADER_BOOTFW, {
+                 {LOADER_REQ_ERROR, LOADER_ERROR},
+                 {LOADER_REQ_SECBREACH, LOADER_SECBREACH},
+                 {0xff, 0xff},
+                 }
+     },
+    {LOADER_ERROR, {
+                 {0xff, 0xff},
+                 {0xff, 0xff},
+                 {0xff, 0xff},
+                 }
+     },
+    {LOADER_SECBREACH, {
+                 {0xff, 0xff},
+                 {0xff, 0xff},
+                 {0xff, 0xff},
+                 }
+     },
+};
+
+/**********************************************
+ * loader getters and setters
+ *********************************************/
+
+loader_state_t loader_get_state(void)
+{
+    return state;
+}
+
+
+/*
+ * This function is eligible in both main thread and ISR
+ * mode (through trigger execution).
+ */
+void loader_set_state(const loader_state_t new_state)
+{
+    if (new_state == 0xff) {
+        dbg_log("%s: PANIC! this should never arise !", __func__);
+        dbg_flush();
+        loader_set_state(LOADER_ERROR);
+        return;
+    }
+#if LOADER_DEBUG
+    dbg_log("%s: state: %x => %x\n", __func__, state, new_state);
+    dbg_flush();
+#endif
+    state = new_state;
+}
+
+/******************************************************
+ * loader automaton management function (transition and
+ * state check)
+ *****************************************************/
+
+/*!
+ * \brief return the next automaton state
+ *
+ * The next state is returned depending on the current state
+ * and the current request. In some case, it can be 0xff if multiple
+ * next states are possible.
+ *
+ * \param current_state the current automaton state
+ * \param request       the current transition request
+ *
+ * \return the next state, or 0xff
+ */
+loader_state_t loader_next_state(const loader_state_t current_state,
+                                 const loader_request_t request)
+{
+    for (uint8_t i = 0; i < MAX_TRANSITION_STATE; ++i) {
+        if (loader_automaton[current_state].req_trans[i].request == request) {
+            return (loader_automaton[current_state].req_trans[i].target_state);
+        }
+    }
+    /* fallback, no corresponding request found for  this state */
+    return 0xff;
+}
+
+/*!
+ * \brief Specify if the current request is valid for the current state
+ *
+ * \param current_state the current automaton state
+ * \param request       the current transition request
+ *
+ * \return true if the transition request is allowed for this state, or false
+ */
+secbool loader_is_valid_transition(const loader_state_t current_state,
+                                   const loader_request_t request)
+{
+    for (uint8_t i = 0; i < MAX_TRANSITION_STATE; ++i) {
+        if (loader_automaton[current_state].req_trans[i].request == request) {
+            return sectrue;
+        }
+    }
+    /*
+     * Didn't find any request associated to current state. This is not a
+     * valid transition. We should stall the request.
+     */
+    dbg_log("%s: invalid transition from state %d, request %d\n", __func__,
+           current_state, request);
+    loader_set_state(LOADER_ERROR);
+    return secfalse;
+}

--- a/src/automaton.h
+++ b/src/automaton.h
@@ -1,0 +1,71 @@
+/*
+ *
+ * Copyright 2018 The wookey project team <wookey@ssi.gouv.fr>
+ *   - Ryad     Benadjila
+ *   - Arnauld  Michelizza
+ *   - Mathieu  Renard
+ *   - Philippe Thierry
+ *   - Philippe Trebuchet
+ *
+ * This package is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * the Free Software Foundation; either version 2.1 of the License, or (at
+ * ur option) any later version.
+ *
+ * This package is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this package; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+#ifndef AUTOMATON_H_
+#define AUTOMATON_H_
+
+#include "arch/cores/armv7-m/types.h"
+#include "debug.h"
+
+typedef enum loader_state {
+    LOADER_START       = 0x0,
+    LOADER_INIT,
+    LOADER_RDPCHECK,
+    LOADER_DFUWAIT,
+    LOADER_SELECTBANK,
+    LOADER_HDRCRC,
+    LOADER_FWINTEGRITY,
+    LOADER_FLASHLOCK,
+    LOADER_BOOTFW,
+    LOADER_ERROR,
+    LOADER_SECBREACH,
+} loader_state_t;
+
+/*
+ * transition requests, like states, should be fault resilient.
+ * TODO: this has to be added.
+ */
+typedef enum loader_request {
+    LOADER_REQ_INIT,
+    LOADER_REQ_RDPCHECK,
+    LOADER_REQ_DFUCHECK,
+    LOADER_REQ_SELECTBANK,
+    LOADER_REQ_CRCCHECK,
+    LOADER_REQ_INTEGRITYCHECK,
+    LOADER_REQ_FLASHLOCK,
+    LOADER_REQ_BOOT,
+    LOADER_REQ_ERROR,
+    LOADER_REQ_SECBREACH,
+} loader_request_t;
+
+loader_state_t loader_get_state(void);
+
+void           loader_set_state(const loader_state_t new_state);
+
+loader_state_t loader_next_state(const loader_state_t current_state,
+                                 const loader_request_t request);
+
+secbool        loader_is_valid_transition(const loader_state_t current_state,
+                                          const loader_request_t request);
+
+#endif /*!LOADER_AUTOMATON_H_ */

--- a/src/debug.c
+++ b/src/debug.c
@@ -51,6 +51,8 @@ static struct {
     char buf[BUF_MAX];
 } ring_buffer;
 
+static bool debug_ready = false;
+
 void init_ring_buffer(void)
 {
     /* init flags */
@@ -115,6 +117,7 @@ void debug_console_init(void)
 
     /* Initialize the USART related to the console */
     soc_usart_init(&console_config);
+    debug_ready = true;
     dbg_log("[USART%d initialized for console output, baudrate=%d]\n",
             console_config.usart, console_config.baudrate);
     dbg_flush();
@@ -204,6 +207,9 @@ static inline void ring_buffer_write_string(char *str, uint32_t len)
 /* flush behavior with activated serial... */
 void dbg_flush(void)
 {
+    if (!debug_ready) {
+        return;
+    }
     if (console_putc == NULL) {
         panic("Error: console_putc not initialized");
     }
@@ -586,6 +592,9 @@ int dbg_log(const char *fmt, ...)
     va_list args;
     logsize_t  len;
 
+    if (!debug_ready) {
+        return 0;
+    }
     /*
      * if there is some asyncrhonous printf to pass to the kernel, do it
      * before execute the current printf command

--- a/src/main.c
+++ b/src/main.c
@@ -393,10 +393,9 @@ static loader_request_t loader_exec_req_crccheck(loader_state_t nextstate)
 {
     loader_set_state(nextstate);
 
-#ifdef CONFIG_WOOKEY
     {
         /* Sanity check on the current selected partition and the header in flash */
-        if (ctx.boot_flip == sectrue){
+        if (ctx.boot_flip == sectrue) {
             if((ctx.fw)->fw_sig.type != PART_FLIP){
                 dbg_log(COLOR_REDBG "Error: FLIP selected, but partition type in flash header is not conforming!\n" COLOR_NORMAL);
                 dbg_flush();
@@ -412,7 +411,7 @@ static loader_request_t loader_exec_req_crccheck(loader_state_t nextstate)
             }
         }
 #endif
-        else{
+        else {
            goto err;
         }
     }
@@ -448,7 +447,7 @@ static loader_request_t loader_exec_req_crccheck(loader_state_t nextstate)
             goto err;
         }
     }
-#endif
+
     return LOADER_REQ_INTEGRITYCHECK;
 err:
     return LOADER_REQ_SECBREACH;
@@ -482,10 +481,12 @@ static loader_request_t loader_exec_req_integritycheck(loader_state_t nextstate)
         goto err;
     }
 
-# endif
+#endif
     return LOADER_REQ_FLASHLOCK;
+#ifdef CONFIG_LOADER_FW_HASH_CHECK
 err:
     return LOADER_REQ_SECBREACH;
+#endif
 }
 
 static loader_request_t loader_exec_req_flashlock(loader_state_t nextstate)


### PR DESCRIPTION
Clean rewrite of the bootloader using a formal automaton implementation instead of a long main.

transition logic has been keeped from the previous implementation. Only the automaton sequence has been formalized properly. This permit to use multiple smaller functions instead of long, unreadable and hard to understand sequences of code.

The automaton formalism is linear and defined in automaton.c.
