### PR TITLE
[enhancement] add support for bootloader code & bootinfo writelock

### DIFF
--- a/src/arch/socs/stm32f439/soc-flash.h
+++ b/src/arch/socs/stm32f439/soc-flash.h
@@ -289,5 +289,6 @@
 #define FLASH_OPTCR_nWRP_9                   ((uint32_t)0x02000000)
 #define FLASH_OPTCR_nWRP_10                  ((uint32_t)0x04000000)
 #define FLASH_OPTCR_nWRP_11		     ((uint32_t)0x08000000)
+#define FLASH_OPTCR_SPRMOD		     ((uint32_t)0x80000000)
 
 #endif /* !SOC_FLASH_H */

--- a/src/flash.c
+++ b/src/flash.c
@@ -826,11 +826,15 @@ t_flash_rdp_state flash_check_rdpstate(void)
 void flash_lock_bootloader(void)
 {
     /* set write mode protection to write protect (not PCROP) */
+#ifdef STM32F429                /* STM32F42xxx/STM32F43xxx only */
     set_reg(r_CORTEX_M_FLASH_OPTCR, 0x0, FLASH_OPTCR_SPRMOD);
+#endif
     /* lock bootloader and bootinfo write access on flashbank1 */
     set_reg(r_CORTEX_M_FLASH_OPTCR, 0xFFc, FLASH_OPTCR_nWRP);
 #if CONFIG_FIRMWARE_DUALBANK && CONFIG_USR_DRV_FLASH_2M
+# ifdef STM32F429                /* STM32F42xxx/STM32F43xxx only */
     set_reg(r_CORTEX_M_FLASH_OPTCR1, 0x0, FLASH_OPTCR_SPRMOD);
+# endif
     set_reg(r_CORTEX_M_FLASH_OPTCR1, 0xFFc, FLASH_OPTCR_nWRP);
 #endif
 }

--- a/src/flash.c
+++ b/src/flash.c
@@ -788,6 +788,8 @@ void flash_writelock_bank1(void)
 void flash_writelock_bank2(void)
 {
 #if CONFIG_FIRMWARE_DUALBANK && CONFIG_USR_DRV_FLASH_2M
+
+
     set_reg(r_CORTEX_M_FLASH_OPTCR1, 0x000, FLASH_OPTCR1_nWRP);
 #endif
 }
@@ -819,4 +821,16 @@ t_flash_rdp_state flash_check_rdpstate(void)
         return FLASH_RDP_CHIPPROTECT;
     }
     return FLASH_RDP_MEMPROTECT;
+}
+
+void flash_lock_bootloader(void)
+{
+    /* set write mode protection to write protect (not PCROP) */
+    set_reg(r_CORTEX_M_FLASH_OPTCR, 0x0, FLASH_OPTCR_SPRMOD);
+    /* lock bootloader and bootinfo write access on flashbank1 */
+    set_reg(r_CORTEX_M_FLASH_OPTCR, 0xFFc, FLASH_OPTCR_nWRP);
+#if CONFIG_FIRMWARE_DUALBANK && CONFIG_USR_DRV_FLASH_2M
+    set_reg(r_CORTEX_M_FLASH_OPTCR1, 0x0, FLASH_OPTCR_SPRMOD);
+    set_reg(r_CORTEX_M_FLASH_OPTCR1, 0xFFc, FLASH_OPTCR_nWRP);
+#endif
 }

--- a/src/flash.h
+++ b/src/flash.h
@@ -238,5 +238,7 @@ void flash_writeunlock_bank2(void);
 
 t_flash_rdp_state flash_check_rdpstate(void);
 
+void flash_lock_bootloader(void);
+
 #endif /* _STM32F4XX_FLASH_H */
 

--- a/src/main.c
+++ b/src/main.c
@@ -170,6 +170,12 @@ static loader_request_t loader_exec_req_init(loader_state_t nextstate)
     core_systick_init();
     // button now managed at kernel boot to detect if DFU mode
     debug_console_init();
+
+    /* self protecting own code write access */
+    flash_unlock_opt();
+    flash_lock_bootloader();
+    flash_lock_opt();
+
     enable_irq();
 
     dbg_log("======= Wookey Loader ========\n");


### PR DESCRIPTION
- Lock write access to flash sectors corresponding to the booloader code and rodata sections
- Lock write access to bootinfos header in both bank1 and bank2
