### PR TITLE
[update] Removed ldscript dynamic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,13 @@ addons:
             - zip
             - unzip
             - bash
+            - wget
 
 # installing dependencies
 before_install:
     - pip install --user intelhex
     - sudo pip3 install kconfiglib
-    - curl -o /tmp/gnat-community-2018-20180524-arm-elf-linux64-bin http://mirrors.cdn.adacore.com/art/5b0c1227a3f5d7097625478d
+    - wget -O /tmp/gnat-community-2018-20180524-arm-elf-linux64-bin https://community.download.adacore.com/v1/6696259f92b40178ab1cc1d3e005acf705dc4162?filename=gnat-community-2019-20190517-arm-elf-linux64-bin
     - chmod +x /tmp/gnat-community-2018-20180524-arm-elf-linux64-bin
     - git clone https://github.com/AdaCore/gnat_community_install_script.git /tmp/gnat_install
     - /tmp/gnat_install/install_package.sh /tmp/gnat-community-2018-20180524-arm-elf-linux64-bin /opt/adacore-arm-eabi

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,11 @@ CFLAGS += -Isrc/ -Iinc/ -Isrc/arch -Isrc/arch/cores/$(ARCH) -Isrc/arch/socs/$(SO
 CFLAGS += -MMD -MP
 CFLAGS += -O0 # required by hardened programing
 
-LDFLAGS := -Tloader.ld $(AFLAGS) -fno-builtin -nostdlib -nostartfiles -Wl,-Map=$(APP_BUILD_DIR)/$(APP_NAME).map
+ifeq ($(CONFIG_USR_DRV_FLASH_DUAL_BANK),y)
+LDFLAGS := -Tloader.dualbank.ld $(AFLAGS) -fno-builtin -nostdlib -nostartfiles -Wl,-Map=$(APP_BUILD_DIR)/$(APP_NAME).map
+else
+LDFLAGS := -Tloader.monobank.ld $(AFLAGS) -fno-builtin -nostdlib -nostartfiles -Wl,-Map=$(APP_BUILD_DIR)/$(APP_NAME).map
+endif
 LD_LIBS += -lsign -L$(APP_BUILD_DIR) -L$(BUILD_DIR)/externals
 
 BUILD_DIR ?= $(PROJ_FILE)build
@@ -101,17 +105,8 @@ $(APP_BUILD_DIR)/arch/cores/$(ARCH)/%.o: arch/cores/$(ARCH)/%.c
 $(APP_BUILD_DIR)/tests/%.o: $(TESTSSRC_DIR)/%.c
 	$(call if_changed,cc_o_c)
 
-# LDSCRIPT
-ifeq (y, $(CONFIG_FIRMWARE_MODE_MONO_BANK))
-$(LDSCRIPT_NAME): loader.monobank.ld.in
-	$(call if_changed,k_ldscript)
-else
-$(LDSCRIPT_NAME): loader.dualbank.ld.in
-	$(call if_changed,k_ldscript)
-endif
-
 # ELF
-$(APP_BUILD_DIR)/$(ELF_NAME): $(LDSCRIPT_NAME) $(OBJ) $(ARCH_OBJ) $(SOC_OBJ) $(SOCASM_OBJ)
+$(APP_BUILD_DIR)/$(ELF_NAME): $(OBJ) $(ARCH_OBJ) $(SOC_OBJ) $(SOCASM_OBJ)
 	$(call if_changed,link_o_target)
 
 # HEX

--- a/loader.dualbank.ld
+++ b/loader.dualbank.ld
@@ -6,7 +6,16 @@ ENTRY(Reset_Handler)
 
 _estack = 0x20002000;
 /* */
-INCLUDE BUILDDIR/layout.ld
+MEMORY
+{
+  /* sample flash, 512k */
+  LDR (rx) : ORIGIN = 0x08000000, LENGTH = 0x00008000
+  SHR_FLIP (rw) : ORIGIN = 0x08008000, LENGTH = 0x00008000
+  SHR_FLOP (rw) : ORIGIN = 0x08108000, LENGTH = 0x00008000
+  /* sample RAM, 128k is enough for loader */
+  RAM_USER   (rx) : ORIGIN = 0x20000000, LENGTH = 0x00020000
+}
+
 
 
 /* Define output sections */
@@ -62,6 +71,11 @@ SECTIONS
     KEEP(*(.shared_flip)) ;
   }>SHR_FLIP
 
+  .shared_flop :    {
+    . = ALIGN(4);
+    KEEP(*(.shared_flop)) ;
+  }>SHR_FLOP
+
   /* Initialized data sections goes into RAM, load LMA copy after code */
   .data : AT ( _sidata )
   {
@@ -98,8 +112,7 @@ SECTIONS
     . = ALIGN(4);
     PROVIDE ( end = . );
     PROVIDE ( _end = . );
-    . = . + _Min_Heap_Size;
-    . = . + _Min_Stack_Size;
+    . = . + 4096;
     . = ALIGN(4);
   } >RAM_USER
 

--- a/loader.monobank.ld
+++ b/loader.monobank.ld
@@ -6,7 +6,15 @@ ENTRY(Reset_Handler)
 
 _estack = 0x20002000;
 /* */
-INCLUDE BUILDDIR/layout.ld
+MEMORY
+{
+  /* sample flash, 512k */
+  LDR (rx) : ORIGIN = 0x08000000, LENGTH = 0x00008000
+  SHR_FLIP (rw) : ORIGIN = 0x08008000, LENGTH = 0x00008000
+  /* sample RAM, 128k is enough for loader */
+  RAM_USER   (rx) : ORIGIN = 0x20000000, LENGTH = 0x00020000
+}
+
 
 
 /* Define output sections */
@@ -62,11 +70,6 @@ SECTIONS
     KEEP(*(.shared_flip)) ;
   }>SHR_FLIP
 
-  .shared_flop :    {
-    . = ALIGN(4);
-    KEEP(*(.shared_flop)) ;
-  }>SHR_FLOP
-
   /* Initialized data sections goes into RAM, load LMA copy after code */
   .data : AT ( _sidata )
   {
@@ -103,8 +106,7 @@ SECTIONS
     . = ALIGN(4);
     PROVIDE ( end = . );
     PROVIDE ( _end = . );
-    . = . + _Min_Heap_Size;
-    . = . + _Min_Stack_Size;
+    . = . + 4096;
     . = ALIGN(4);
   } >RAM_USER
 


### PR DESCRIPTION
Previous ldscripts was dynamically built, based on kernel toolset. The bootloader, by now, is designed for STM32F4, and its ldscript build should not depend on external components (other the SDK basics).

This patch remove the dependency on the kernel tools in the bootloader link target.

This patch also prepare for the kernel new memory handling mechanism PR